### PR TITLE
Adding _init_private_attributes to SQLModel __init__ function.

### DIFF
--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -514,6 +514,7 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
         for key in non_pydantic_keys:
             if key in __pydantic_self__.__sqlmodel_relationships__:
                 setattr(__pydantic_self__, key, data[key])
+        __pydantic_self__._init_private_attributes()
 
     def __setattr__(self, name: str, value: Any) -> None:
         if name in {"_sa_instance_state"}:

--- a/tests/test_private_attributes.py
+++ b/tests/test_private_attributes.py
@@ -1,0 +1,18 @@
+from typing import Optional
+
+from pydantic import PrivateAttr
+from sqlmodel import Field, SQLModel
+
+
+def test_private_attribute():
+    class Hero(SQLModel, table=True):
+        primary_key: Optional[int] = Field(
+            default=None,
+            primary_key=True,
+        )
+        _private_attribute: str = PrivateAttr(default="my_private_attribute")
+
+    hero = Hero()
+    assert hero._private_attribute == "my_private_attribute"
+    assert "primary_key" in hero.dict()
+    assert "_private_attribute" not in hero.dict()


### PR DESCRIPTION
## Fixing:

Private attributes cannot be used in SQLModel. Attributes initialized with `PrivateAttr` cannot be found.

## Proposed solution:
Add a [missing line](https://github.com/pydantic/pydantic/blob/da7e6f89a740793a1a6cf2bb5a1883ee8575f76a/pydantic/main.py#L350) from Pydantic source code.

_Note_: the class method [from_orm](https://github.com/tiangolo/sqlmodel/blob/75ce45588b6a13136916929be4c44946f7e00cbd/sqlmodel/main.py#L563) does have this initialization.

## Related issues:

https://github.com/tiangolo/sqlmodel/issues/149 mentions this issue




## Disclaimer

This is my first-ever contribution to an open-source project. I would appreciate any kind of feedback.