### PR TITLE
Add kwargs to ForeignKey definitions

### DIFF
--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -61,6 +61,7 @@ class FieldInfo(PydanticFieldInfo):
         primary_key = kwargs.pop("primary_key", False)
         nullable = kwargs.pop("nullable", Undefined)
         foreign_key = kwargs.pop("foreign_key", Undefined)
+        foreign_key_kwargs = kwargs.pop("foreign_key_kwargs", Undefined)
         unique = kwargs.pop("unique", False)
         index = kwargs.pop("index", Undefined)
         sa_column = kwargs.pop("sa_column", Undefined)
@@ -81,6 +82,7 @@ class FieldInfo(PydanticFieldInfo):
         self.primary_key = primary_key
         self.nullable = nullable
         self.foreign_key = foreign_key
+        self.foreign_key_kwargs = foreign_key_kwargs
         self.unique = unique
         self.index = index
         self.sa_column = sa_column
@@ -143,6 +145,7 @@ def Field(
     regex: Optional[str] = None,
     primary_key: bool = False,
     foreign_key: Optional[Any] = None,
+    foreign_key_kwargs: Optional[Mapping[str, Any]] = None,
     unique: bool = False,
     nullable: Union[bool, UndefinedType] = Undefined,
     index: Union[bool, UndefinedType] = Undefined,
@@ -174,6 +177,7 @@ def Field(
         regex=regex,
         primary_key=primary_key,
         foreign_key=foreign_key,
+        foreign_key_kwargs=foreign_key_kwargs,
         unique=unique,
         nullable=nullable,
         index=index,
@@ -432,9 +436,10 @@ def get_column_from_field(field: ModelField) -> Column:  # type: ignore
             nullable = field_nullable
     args = []
     foreign_key = getattr(field.field_info, "foreign_key", None)
+    foreign_key_kwargs = getattr(field.field_info, "foreign_key_kwargs", None)
     unique = getattr(field.field_info, "unique", False)
     if foreign_key:
-        args.append(ForeignKey(foreign_key))
+        args.append(ForeignKey(foreign_key, **(foreign_key_kwargs or dict())))
     kwargs = {
         "primary_key": primary_key,
         "nullable": nullable,


### PR DESCRIPTION
`ForeignKey` definitions in SqlAlchemy accept kwargs such as `onupdate` and `ondelete` that determine the behaviour of the foreign key at the DB level. This PR adds the option to provide kwargs to the `ForeignKey` definition under the hood. In my case, I used it to control delete behaviour when deleting a model that did not maintain back references (relationships) with its child models. Example -- an application where users can have 0 or 1 "Repository": 

```
class Repository(SQLModel, table=True):
  id: int = Field(primary_key=True)
  ...

class User(SQLModel, table=True):
  ...
  name: str
  repository_id: int | None = Field(foreign_key='repository.id', 
                                                        foreign_key_kwargs={'ondelete': 'SET NULL'})
  repository: Repository | None = Relationship()


# -- first create a user without a repository
user = User(name='some user')
session.add(user)
session.flush()

# -- create and add the repository
rep = Repository()
user.repository = rep

session.add(rep)
session.flush()

session.commit()

# -- now delete the user's repository
session.delete(rep)
session.commit()
```

If we didn't set the `ondelete="SET NULL"` option on the `user.repository_id` foreign key we would get this error:
> psycopg2.errors.ForeignKeyViolation: update or delete on table "repository" violates foreign key constraint "user_repository_id_fkey" on table "user".  Key (id)=(1) is still referenced from table "user" .

A workaround for this would be to keep a `user: User = Relationship(back_populates='repository')` attribute which I didn't want to do because in my case it would clutter my model. I'm wondering whether there are more concrete use cases for the `foreign_key_kwargs` option.