### PR TITLE
add python version 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
       fail-fast: false
 
     steps:
@@ -70,17 +71,27 @@ jobs:
         with:
           name: coverage
           path: coverage
+
   coverage-combine:
     needs:
       - test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11"
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: ${{ matrix.python-version }}
 
       - name: Get coverage files
         uses: actions/download-artifact@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,22 +76,13 @@ jobs:
     needs:
       - test
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version:
-          - "3.7"
-          - "3.8"
-          - "3.9"
-          - "3.10"
-          - "3.11"
-      fail-fast: false
 
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.8'
 
       - name: Get coverage files
         uses: actions/download-artifact@v3


### PR DESCRIPTION
I have added Python 3.11 to the GitHub Actions test workflow for this library. I plan to use Python 3.11 for work, so I want to make sure that this library is compatible with it.

Please let me know if there's anything else needed for this update.