### PR TITLE
📝 Update docs to advise against using `from __future__ import annotations`

### DIFF
--- a/docs/tutorial/relationship-attributes/type-annotation-strings.md
+++ b/docs/tutorial/relationship-attributes/type-annotation-strings.md
@@ -16,15 +16,17 @@ In the first Relationship attribute, we declare it with `List["Hero"]`, putting 
 
 ///
 
-What's that about? Can't we just write it normally as `List[Hero]`?
+What's that about? Can't we just write it normally as `List[Hero]`? 
 
-By that point, in that line in the code, the Python interpreter **doesn't know of any class `Hero`**, and if we put it just there, it would try to find it unsuccessfully, and then fail. 😭
+By that point, in that line in the code, the Python interpreter **doesn't know of any class `Hero`**, and if we put it just there, it would try to find it unsuccessfully, and then fail. 😭 
+
+Unlike some other Python features, SQLModel does not require the import `from __future__ import annotations` to handle forward referenced type annotations. In fact, when working with SQLModel, this import will disrupt the mapping of forward referenced types. 
 
 But by putting it in quotes, in a string, the interpreter sees it as just a string with the text `"Hero"` inside.
 
 But the editor and other tools can see that **the string is actually a type annotation inside**, and provide all the autocompletion, type checks, etc. 🎉
 
-And of course, **SQLModel** can also understand it in the string correctly. ✨
+And of course, **SQLModel** can also understand it in the string correctly. ✨ 
 
 That is actually part of Python, it's the current official solution to handle it.
 

--- a/docs/tutorial/relationship-attributes/type-annotation-strings.md
+++ b/docs/tutorial/relationship-attributes/type-annotation-strings.md
@@ -16,7 +16,7 @@ In the first Relationship attribute, we declare it with `List["Hero"]`, putting 
 
 ///
 
-What's that about? Can't we just write it normally as `List[Hero]`? 
+What's that about? Can't we just write it normally as `List[Hero]`?
 
 By that point, in that line in the code, the Python interpreter **doesn't know of any class `Hero`**, and if we put it just there, it would try to find it unsuccessfully, and then fail. 😭 
 
@@ -26,7 +26,7 @@ But by putting it in quotes, in a string, the interpreter sees it as just a stri
 
 But the editor and other tools can see that **the string is actually a type annotation inside**, and provide all the autocompletion, type checks, etc. 🎉
 
-And of course, **SQLModel** can also understand it in the string correctly. ✨ 
+And of course, **SQLModel** can also understand it in the string correctly. ✨
 
 That is actually part of Python, it's the current official solution to handle it.
 

--- a/docs/tutorial/relationship-attributes/type-annotation-strings.md
+++ b/docs/tutorial/relationship-attributes/type-annotation-strings.md
@@ -18,9 +18,9 @@ In the first Relationship attribute, we declare it with `List["Hero"]`, putting 
 
 What's that about? Can't we just write it normally as `List[Hero]`?
 
-By that point, in that line in the code, the Python interpreter **doesn't know of any class `Hero`**, and if we put it just there, it would try to find it unsuccessfully, and then fail. 😭 
+By that point, in that line in the code, the Python interpreter **doesn't know of any class `Hero`**, and if we put it just there, it would try to find it unsuccessfully, and then fail. 😭
 
-Unlike some other Python features, SQLModel does not require the import `from __future__ import annotations` to handle forward referenced type annotations. In fact, when working with SQLModel, this import will disrupt the mapping of forward referenced types. 
+Unlike some other Python features, SQLModel does not require the import `from __future__ import annotations` to handle forward referenced type annotations. In fact, when working with SQLModel, this import will disrupt the mapping of forward referenced types.
 
 But by putting it in quotes, in a string, the interpreter sees it as just a string with the text `"Hero"` inside.
 


### PR DESCRIPTION
Hi all!

I've made this documentation PR after encountering [issue 196](https://github.com/tiangolo/sqlmodel/issues/196#issuecomment-1884097452). Many devs are accustomed to using the `from __future__ import annotations` import when working with forward references. Even though the docs page for [type annotation strings](https://sqlmodel.tiangolo.com/tutorial/relationship-attributes/type-annotation-strings/) explains how to work with forward reference type annotation strings with no mention of needing that import, myself an several others have perhaps by habit or assumption included the import and spent time scratching our heads at the mapping errors the import creates.

Python is [close to making this future feature part of the language](https://docs.python.org/3/library/__future__.html#id1), but given that it is still up in the air, I think it's worth calling out how SQLModel interacts with this import in the interim.

Thanks!