### PR TITLE
Add hash to model with primary key

### DIFF
--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -735,6 +735,21 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
             if not (isinstance(k, str) and k.startswith("_sa_"))
         ]
 
+    def __hash__(self) -> int:
+        # If there's a primary key, use that to hash the object
+        to_hash = ""
+
+        for field in self.__fields__:
+            is_primary_key = getattr(
+                self.__fields__[field].field_info, "primary_key", False
+            )
+            if is_primary_key:
+                to_hash += str(getattr(self, field))
+        if not to_hash:
+            # Can't call super().__hash__ because BaseModel.__hash__ is a NoneType
+            raise TypeError(f"unhashable type: '{self.__class__.__name__}'")
+        return hash(to_hash)
+
     @declared_attr  # type: ignore
     def __tablename__(cls) -> str:
         return cls.__name__.lower()


### PR DESCRIPTION
This PR adds a hash function to models which contain a primary key relation. 
We know that a primary key does indeed offer a unique identifier for the row, and a concat of the primary key fields can thus be used to create a unique string identifying the row.

A use case for this would be the following. 
Consider a select on the join of 2 tables, A and B. 
In the resulting sequence of tuples, multiple instances of a row of either A or B can be present, as they match multiple times on their counterpart. 

The most pythonic way to then retrieve the unique instances / rows of either A or B in the result set would be as follows.

```python
# Retrieving the joined tuples, where A and B have 1 to many relationships.
statement = select(A, B).join(B, A.id == B.id)
result: Sequence[tuple[A,B]] = session.exec(statement).all()

# Unique instances of A
unique_a: list[A] = list(set([a for a, b in result]))

# Unique instances of B
unique_b: list[B] = list(set([b for a, b in result]))
```

This is currently not possible as the SQLModel class, and the underlying pydantic BaseModel are unhashable.
However, I propose that a SQLModel with properly defined primary keys IS actually hashable, as the primary key defines a unique, hashable property.
This would be in line with the underlying database, as some hash is ofcourse also used in the backend to identify this uniqueness.