### PR TITLE
💚 Set `include-hidden-files` to `True` when using the `upload-artifact` GH action

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -77,6 +77,7 @@ jobs:
         with:
           name: docs-site
           path: ./site/**
+          include-hidden-files: true
 
   # https://github.com/marketplace/actions/alls-green#why
   docs-all-green:  # This job does nothing and is only used for the branch protection

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,8 @@ jobs:
         with:
           name: coverage-${{ matrix.python-version }}-${{ matrix.pydantic-version }}
           path: coverage
+          include-hidden-files: true
+
   coverage-combine:
     needs:
       - test
@@ -107,6 +109,7 @@ jobs:
         with:
           name: coverage-html
           path: htmlcov
+          include-hidden-files: true
 
   # https://github.com/marketplace/actions/alls-green#why
   alls-green:  # This job does nothing and is only used for the branch protection


### PR DESCRIPTION
Since `actions/upload-artifact` [v4.4.0](https://github.com/actions/upload-artifact/releases/tag/v4.4.0), hidden files are excluded by default. This PR specifically sets the `include-hidden-files` parameter to `True` to ensure all behaviour remains the same as before.
