### PR TITLE
✏️ Fix typo in the release notes of v0.0.22

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -36,7 +36,7 @@
 
 ### Fixes
 
-* 🐛 Fix support for types with `Optional[Annoated[x, f()]]`, e.g. `id: Optional[pydantic.UUID4]`. PR [#1093](https://github.com/fastapi/sqlmodel/pull/1093) by [@tiangolo](https://github.com/tiangolo).
+* 🐛 Fix support for types with `Optional[Annotated[x, f()]]`, e.g. `id: Optional[pydantic.UUID4]`. PR [#1093](https://github.com/fastapi/sqlmodel/pull/1093) by [@tiangolo](https://github.com/tiangolo).
 
 ### Docs
 


### PR DESCRIPTION
`Annoated` -> `Annotated`