### PR TITLE
Support upcoming changes in Pydantic version 2.10.

### DIFF
--- a/sqlmodel/_compat.py
+++ b/sqlmodel/_compat.py
@@ -252,7 +252,8 @@ if IS_PYDANTIC_V2:
             elif name in values:
                 fields_values[name] = values.pop(name)
             elif not field.is_required():
-                defaults[name] = field.get_default(call_default_factory=True)
+                defaults[name] = field.get_default(call_default_factory=True,
+                                                   validated_data=fields_values)
         if _fields_set is None:
             _fields_set = set(fields_values.keys())
         fields_values.update(defaults)


### PR DESCRIPTION
Without this fix, any SQLModel-based model with `table=True` and a `Field` that sets `default_factory=...` will brake with the following error message: `ValueError: 'validated_data' must be provided if 'call_default_factory' is True.`

To reproduce, before this fix is applied:

- Install all project dependencies, then upgrade Pydantic:
  ```shell
  pip install -r requirements.txt
  pip install pydantic==2.10.0b2
  ```

- Run the test suite:
  ```shell
  python -m pytest tests
  ```

… which will give the following output:
```
[…]
=================================================================== short test summary info ====================================================================
FAILED tests/test_annotated_uuid.py::test_annotated_optional_types - ValueError: 'validated_data' must be provided if 'call_default_factory' is True.
FAILED tests/test_advanced/test_uuid/test_tutorial001.py::test_tutorial - ValueError: 'validated_data' must be provided if 'call_default_factory' is True.
FAILED tests/test_advanced/test_uuid/test_tutorial001_py310.py::test_tutorial - ValueError: 'validated_data' must be provided if 'call_default_factory' is True.
FAILED tests/test_advanced/test_uuid/test_tutorial002.py::test_tutorial - ValueError: 'validated_data' must be provided if 'call_default_factory' is True.
FAILED tests/test_advanced/test_uuid/test_tutorial002_py310.py::test_tutorial - ValueError: 'validated_data' must be provided if 'call_default_factory' is True.
===================================================== 5 failed, 250 passed, 3 skipped, 7 warnings in 9.37s =====================================================
```
