### PR TITLE
🐛 Fix Pydantic version check for version 2.10.x onwards

### DIFF
--- a/sqlmodel/_compat.py
+++ b/sqlmodel/_compat.py
@@ -25,7 +25,8 @@ from typing_extensions import Annotated, get_args, get_origin
 
 # Reassign variable to make it reexported for mypy
 PYDANTIC_VERSION = P_VERSION
-IS_PYDANTIC_V2 = PYDANTIC_VERSION.startswith("2.")
+PYDANTIC_MINOR_VERSION = tuple(int(i) for i in P_VERSION.split(".", 2)[:2])
+IS_PYDANTIC_V2 = PYDANTIC_MINOR_VERSION[0] >= 2
 
 
 if TYPE_CHECKING:

--- a/sqlmodel/_compat.py
+++ b/sqlmodel/_compat.py
@@ -25,8 +25,8 @@ from typing_extensions import Annotated, get_args, get_origin
 
 # Reassign variable to make it reexported for mypy
 PYDANTIC_VERSION = P_VERSION
-PYDANTIC_MINOR_VERSION = tuple(int(i) for i in P_VERSION.split(".", 2)[:2])
-IS_PYDANTIC_V2 = PYDANTIC_MINOR_VERSION[0] >= 2
+PYDANTIC_MINOR_VERSION = tuple(int(i) for i in P_VERSION.split(".")[:2])
+IS_PYDANTIC_V2 = PYDANTIC_MINOR_VERSION[0] == 2
 
 
 if TYPE_CHECKING:

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -56,7 +56,7 @@ from typing_extensions import Literal, TypeAlias, deprecated, get_origin
 
 from ._compat import (  # type: ignore[attr-defined]
     IS_PYDANTIC_V2,
-    PYDANTIC_VERSION,
+    PYDANTIC_MINOR_VERSION,
     BaseConfig,
     ModelField,
     ModelMetaclass,
@@ -874,7 +874,7 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
         warnings: Union[bool, Literal["none", "warn", "error"]] = True,
         serialize_as_any: bool = False,
     ) -> Dict[str, Any]:
-        if PYDANTIC_VERSION >= "2.7.0":
+        if PYDANTIC_MINOR_VERSION >= (2, 7):
             extra_kwargs: Dict[str, Any] = {
                 "context": context,
                 "serialize_as_any": serialize_as_any,


### PR DESCRIPTION
The pydantic version check works incorrectly since the release of pydantic 2.10.* (`"2.10.0" < "2.7.0"`)