### PR TITLE
👷 Fix py3.7 tests, use ubuntu-22.04 for test jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,8 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    # 'ubuntu-latest' does not support 3.7. Pin to 22.04 until we drop support for 3.7
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version:


### PR DESCRIPTION
More info in this thread: https://github.com/actions/setup-python/issues/962

Announcement for moving `ubuntu-latest` to 24.04: https://github.com/actions/runner-images/issues/10636
It says that the setup-python action should be able to install 3.7, but the discussion in https://github.com/actions/setup-python/issues/962 (and the failing pipelines in this repo) say otherwise.