### PR TITLE
⬆️ Add support for Python 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,13 +66,13 @@ jobs:
         with:
           limit-access-to-actor: true
       - name: Install Dependencies
-        run: uv pip install -r requirements-tests.txt
+        run: pip install -r requirements-tests.txt
       - name: Install Pydantic v1
         if: matrix.pydantic-version == 'pydantic-v1'
-        run: uv pip install --upgrade "pydantic>=1.10.0,<2.0.0"
+        run: pip install --upgrade "pydantic>=1.10.0,<2.0.0"
       - name: Install Pydantic v2
         if: matrix.pydantic-version == 'pydantic-v2'
-        run: uv pip install --upgrade "pydantic>=2.0.2,<3.0.0" "typing-extensions==4.6.1"
+        run: pip install --upgrade "pydantic>=2.0.2,<3.0.0" "typing-extensions==4.6.1"
       - name: Lint
         # Do not run on Python 3.7 as mypy behaves differently
         if: matrix.python-version != '3.7' && matrix.pydantic-version == 'pydantic-v2'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,13 +66,16 @@ jobs:
         with:
           limit-access-to-actor: true
       - name: Install Dependencies
-        run: pip install -r requirements-tests.txt
+        run: uv pip install -r requirements-tests.txt
       - name: Install Pydantic v1
         if: matrix.pydantic-version == 'pydantic-v1'
-        run: pip install --upgrade "pydantic>=1.10.0,<2.0.0"
+        run: uv pip install --upgrade "pydantic>=1.10.0,<2.0.0"
       - name: Install Pydantic v2
         if: matrix.pydantic-version == 'pydantic-v2'
-        run: pip install --upgrade "pydantic>=2.0.2,<3.0.0"
+        run: uv pip install --upgrade "pydantic>=2.0.2,<3.0.0"
+      - name: Pin typing-extensions for Python 3.7
+        if: matrix.python-version == '3.7'
+        run: uv pip install --upgrade "typing-extensions==4.6.1"
       - name: Lint
         # Do not run on Python 3.7 as mypy behaves differently
         if: matrix.python-version != '3.7' && matrix.pydantic-version == 'pydantic-v2'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
         run: pip install --upgrade "pydantic>=1.10.0,<2.0.0"
       - name: Install Pydantic v2
         if: matrix.pydantic-version == 'pydantic-v2'
-        run: pip install --upgrade "pydantic>=2.0.2,<3.0.0" "typing-extensions==4.6.1"
+        run: pip install --upgrade "pydantic>=2.0.2,<3.0.0"
       - name: Lint
         # Do not run on Python 3.7 as mypy behaves differently
         if: matrix.python-version != '3.7' && matrix.pydantic-version == 'pydantic-v2'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
         pydantic-version:
           - pydantic-v1
           - pydantic-v2
@@ -90,7 +91,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
       - name: Setup uv
         uses: astral-sh/setup-uv@v5
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Database",
     "Topic :: Database :: Database Engines/Servers",
     "Topic :: Internet",

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -13,6 +13,5 @@ dirty-equals ==0.9.0; python_version >= "3.8"
 jinja2 ==3.1.4
 # Pin typing-extensions until Python 3.8 is deprecated or the issue with dirty-equals
 # is fixed, maybe fixed after dropping Python 3.7 and upgrading dirty-equals
-typing-extensions
 typing-extensions ==4.6.1; python_version < "3.8"
 typing-extensions ==4.12.2; python_version >= "3.8"

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -8,8 +8,11 @@ ruff ==0.6.2
 fastapi >=0.103.2
 httpx ==0.24.1
 # TODO: upgrade when deprecating Python 3.7
-dirty-equals
+dirty-equals ==0.6.0; python_version < "3.8"
+dirty-equals ==0.9.0; python_version >= "3.8"
 jinja2 ==3.1.4
 # Pin typing-extensions until Python 3.8 is deprecated or the issue with dirty-equals
 # is fixed, maybe fixed after dropping Python 3.7 and upgrading dirty-equals
 typing-extensions
+typing-extensions ==4.6.1; python_version < "3.8"
+typing-extensions ==4.12.2; python_version >= "3.8"

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -8,8 +8,8 @@ ruff ==0.6.2
 fastapi >=0.103.2
 httpx ==0.24.1
 # TODO: upgrade when deprecating Python 3.7
-dirty-equals ==0.6.0
+dirty-equals
 jinja2 ==3.1.4
 # Pin typing-extensions until Python 3.8 is deprecated or the issue with dirty-equals
 # is fixed, maybe fixed after dropping Python 3.7 and upgrading dirty-equals
-typing-extensions ==4.6.1
+typing-extensions

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -479,6 +479,7 @@ def Relationship(
 class SQLModelMetaclass(ModelMetaclass, DeclarativeMeta):
     __sqlmodel_relationships__: Dict[str, RelationshipInfo]
     model_config: SQLModelConfig
+    model_fields: Dict[str, FieldInfo]  # type: ignore[assignment]
     __config__: Type[SQLModelConfig]
     __fields__: Dict[str, ModelField]  # type: ignore[assignment]
 

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -93,8 +93,8 @@ NoArgAnyCallable = Callable[[], Any]
 IncEx: TypeAlias = Union[
     Set[int],
     Set[str],
-    Mapping[int, Union["IncEx", Literal[True]]],
-    Mapping[str, Union["IncEx", Literal[True]]],
+    Mapping[int, Union["IncEx", bool]],
+    Mapping[str, Union["IncEx", bool]],
 ]
 OnDeleteType = Literal["CASCADE", "SET NULL", "RESTRICT"]
 
@@ -479,7 +479,6 @@ def Relationship(
 class SQLModelMetaclass(ModelMetaclass, DeclarativeMeta):
     __sqlmodel_relationships__: Dict[str, RelationshipInfo]
     model_config: SQLModelConfig
-    model_fields: Dict[str, FieldInfo]
     __config__: Type[SQLModelConfig]
     __fields__: Dict[str, ModelField]  # type: ignore[assignment]
 


### PR DESCRIPTION
This ended up needing more changes than I had expected:

- To allow a valid resolution of dependencies, for Python 3.13 we need to allow a higher version of `typing-extensions`. This then allows us to pull in [Pydantic 2.8+](https://github.com/pydantic/pydantic/releases/tag/v2.8.0) which supports Python 3.13.
- If we keep the upper version of Pydantic unbounded (`fastapi` imposes "only" `pydanctic<3.0.0`), we would currently pull in Pydantic v.2.10
- Since [Pydantic 2.10.0](https://github.com/pydantic/pydantic/releases/tag/v2.10.0), the definition of `IncEx` has [changed](https://github.com/pydantic/pydantic/pull/10813), which means we need to change it as well or we'll get `mypy` errors complaining about violating the Liskov substitution principle
- In `SQLModelMetaclass`, when we redefine `model_fields`, we'd get this `mypy` error:
```
sqlmodel\main.py:482: error: Incompatible types in assignment (expression has type "dict[str, sqlmodel.main.FieldInfo]", base class "ModelMetaclass" defined the type as "dict[str, pydantic.fields.FieldInfo]")  [assignment]
```
<s>But I don't think we really need to redefine it? We'll be able to pass in a `sqlmodel.main.FieldInfo` object whereever a `pydantic.fields.FieldInfo` is expected, and the rest of the code base / tests / type checks don't seem to complain when we remove the redefinition (L482).</s>

As discussed below with Tiangolo, this PR now just adds an `ignore` statement for this.
