### PR TITLE
💚 Fix test matrix and include testing on Windows and MacOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,16 +26,30 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version:
-          - "3.7"
-          - "3.8"
-          - "3.9"
-          - "3.10"
-          - "3.11"
-          - "3.12"
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        python-version: [ "3.12" ]
         pydantic-version:
           - pydantic-v1
           - pydantic-v2
+        include:
+          - os: ubuntu-22.04
+            python-version: "3.7"
+            pydantic-version: pydantic-v1
+          - os: ubuntu-22.04
+            python-version: "3.7"
+            pydantic-version: pydantic-v2
+          - os: macos-latest
+            python-version: "3.8"
+            pydantic-version: pydantic-v1
+          - os: windows-latest
+            python-version: "3.9"
+            pydantic-version: pydantic-v2
+          - os: ubuntu-latest
+            python-version: "3.10"
+            pydantic-version: pydantic-v1
+          - os: macos-latest
+            python-version: "3.11"
+            pydantic-version: pydantic-v2
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,9 @@ jobs:
           - os: windows-latest
             python-version: "3.9"
             pydantic-version: pydantic-v2
+          - os: macos-latest
+            python-version: "3.9"
+            pydantic-version: pydantic-v2
           - os: ubuntu-latest
             python-version: "3.10"
             pydantic-version: pydantic-v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ ubuntu-latest, macos-latest ]
         python-version: [ "3.12" ]
         pydantic-version:
           - pydantic-v1
@@ -40,7 +40,7 @@ jobs:
           - os: macos-latest
             python-version: "3.8"
             pydantic-version: pydantic-v1
-          - os: windows-latest
+          - os: ubuntu-latest
             python-version: "3.9"
             pydantic-version: pydantic-v2
           - os: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ env:
 
 jobs:
   test:
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         os: ubuntu-latest
@@ -50,7 +51,7 @@ jobs:
 #            python-version: "3.11"
 #            pydantic-version: pydantic-v2
       fail-fast: false
-    runs-on: ${{ matrix.os }}
+#    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,30 +25,30 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: ubuntu-latest
         python-version: [ "3.12" ]
         pydantic-version:
           - pydantic-v1
           - pydantic-v2
-        include:
-          - os: ubuntu-22.04
-            python-version: "3.7"
-            pydantic-version: pydantic-v1
-          - os: ubuntu-22.04
-            python-version: "3.7"
-            pydantic-version: pydantic-v2
-          - os: macos-latest
-            python-version: "3.8"
-            pydantic-version: pydantic-v1
-          - os: ubuntu-latest
-            python-version: "3.9"
-            pydantic-version: pydantic-v2
-          - os: ubuntu-latest
-            python-version: "3.10"
-            pydantic-version: pydantic-v1
-          - os: macos-latest
-            python-version: "3.11"
-            pydantic-version: pydantic-v2
+#        include:
+#          - os: ubuntu-22.04
+#            python-version: "3.7"
+#            pydantic-version: pydantic-v1
+#          - os: ubuntu-22.04
+#            python-version: "3.7"
+#            pydantic-version: pydantic-v2
+#          - os: macos-latest
+#            python-version: "3.8"
+#            pydantic-version: pydantic-v1
+#          - os: ubuntu-latest
+#            python-version: "3.9"
+#            pydantic-version: pydantic-v2
+#          - os: ubuntu-latest
+#            python-version: "3.10"
+#            pydantic-version: pydantic-v1
+#          - os: macos-latest
+#            python-version: "3.11"
+#            pydantic-version: pydantic-v2
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,6 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
@@ -51,6 +50,7 @@ jobs:
             python-version: "3.11"
             pydantic-version: pydantic-v2
       fail-fast: false
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -92,7 +92,7 @@ jobs:
       - name: Store coverage files
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-${{ matrix.python-version }}-${{ matrix.pydantic-version }}
+          name: coverage-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.pydantic-version }}
           path: coverage
           include-hidden-files: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,9 +43,6 @@ jobs:
           - os: windows-latest
             python-version: "3.9"
             pydantic-version: pydantic-v2
-          - os: macos-latest
-            python-version: "3.9"
-            pydantic-version: pydantic-v2
           - os: ubuntu-latest
             python-version: "3.10"
             pydantic-version: pydantic-v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ exclude_lines = [
     'if __name__ == "__main__":',
     "if TYPE_CHECKING:",
 ]
+skip_empty = true
 
 [tool.coverage.html]
 show_contexts = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,6 @@ exclude_lines = [
     'if __name__ == "__main__":',
     "if TYPE_CHECKING:",
 ]
-skip_empty = true
 
 [tool.coverage.html]
 show_contexts = true

--- a/tests/test_select_gen.py
+++ b/tests/test_select_gen.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -10,8 +11,8 @@ root_path = Path(__file__).parent.parent
 @needs_py39
 def test_select_gen() -> None:
     result = subprocess.run(
-        [sys.executable, "scripts/generate_select.py"],
-        env={"CHECK_JINJA": "1"},
+        [sys.executable, Path("scripts") / "generate_select.py"],
+        env={**os.environ, "CHECK_JINJA": "1"},
         check=True,
         cwd=root_path,
         capture_output=True,


### PR DESCRIPTION
The test suite was failing because Python 3.7 can't run on `ubuntu-latest` anymore. Instead, `ubuntu-22.04` does still support Python 3.7.

Also rewrote the test suite to include testing for Windows and MacOS. To avoid getting an exponential number of tests, limiting the testing of older Python versions to just a few different combinations. All in all, now the test suite should have 12 combinations to test (3x1x2 + 6), which is the same as before (6x2x1). So it shouldn't be slower, but it should cover more diverse cases.