### PR TITLE
🐛 Fix type annotation in `Field` constructor

### DIFF
--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -341,7 +341,7 @@ def Field(
     regex: Optional[str] = None,
     discriminator: Optional[str] = None,
     repr: bool = True,
-    sa_column: Union[Column, UndefinedType] = Undefined,  # type: ignore
+    sa_column: Union[Column[Any], UndefinedType] = Undefined,
     schema_extra: Optional[Dict[str, Any]] = None,
 ) -> Any: ...
 


### PR DESCRIPTION
Type checker throw partially unknown error when used in strict mode (Pylance)
When I locally edited that line, everything was correct

the `Column` type needs a type argument, assign it `Any` to accept all instances of the object

origin: sqlmodel.main.Field
info: `Column` expected an argument 
```python
339 |    sa_column: Union[Column, UndefinedType] = Undefined,  # type: ignore
```

proposed change
```python
339 |    sa_column: Union[Column[Any], UndefinedType] = Undefined,
```

If you want to see it yourself (be sure to set the type checker to strict)
```python
import sqlmodel

class TestModel(sqlmodel.SQLModel, table=True):
    value: list[int] = sqlmodel.Field(sa_column=sqlmodel.Column(sqlmodel.JSON))
```

There is a better change, but it is not possible because Column was defined in sqlalchemy
```python
# sqlalchemy.sql.schema
113 |    _T = TypeVar("_T", bound="Any", default="Any")  # python >= 3.13
```