### PR TITLE
💚 Fix CI test suite for Python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: ubuntu-latest
+        os: [ ubuntu-latest ]
         python-version:
           - "3.8"
           - "3.9"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,9 +23,9 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
+        os: ubuntu-latest
         python-version:
           - "3.8"
           - "3.9"
@@ -35,7 +35,15 @@ jobs:
         pydantic-version:
           - pydantic-v1
           - pydantic-v2
+        include:
+          - os: ubuntu-22.04
+            python-version: "3.7"
+            pydantic-version: pydantic-v1
+          - os: ubuntu-22.04
+            python-version: "3.7"
+            pydantic-version: pydantic-v2
       fail-fast: false
+      runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
             python-version: "3.7"
             pydantic-version: pydantic-v2
       fail-fast: false
-      runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python


### PR DESCRIPTION
Python 3.7 can't run on `ubuntu-latest` anymore. Instead, `ubuntu-22.04` does still support Python 3.7.