### PR TITLE
Update docs for response-model

### DIFF
--- a/docs/tutorial/fastapi/response-model.md
+++ b/docs/tutorial/fastapi/response-model.md
@@ -36,9 +36,9 @@ For example, we can pass the same `Hero` **SQLModel** class (because it is also 
 
 ## List of Heroes in `response_model`
 
-We can also use other type annotations, the same way we can use with Pydantic fields. For example, we can pass a list of `Hero`s.
+We can also use other type annotations, the same way we can use with Pydantic fields.
 
-First, we import `List` from `typing` and then we declare the `response_model` with `List[Hero]`:
+For example, we can pass a list of `Hero`s to `response_model`.
 
 {* ./docs_src/tutorial/fastapi/response_model/tutorial001_py310.py ln[40:44] hl[40] *}
 


### PR DESCRIPTION
As of [Python 3.9](https://docs.python.org/3/whatsnew/3.9.html#type-hinting-generics-in-standard-collections), you no longer have to use `List` from typing for type hinting.

The code example is updated but there is a sentence that was not updated accordingly in docs.


![Screenshot 2025-02-27 at 11 40 04 AM](https://github.com/user-attachments/assets/9f1d53c8-c1e8-408d-8d07-edb2a1d8327a)
