### PR TITLE
⬆️ Drop support for Python 3.7, require Python 3.8 or above

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,13 +36,6 @@ jobs:
         pydantic-version:
           - pydantic-v1
           - pydantic-v2
-        include:
-          - os: ubuntu-22.04
-            python-version: "3.7"
-            pydantic-version: pydantic-v1
-          - os: ubuntu-22.04
-            python-version: "3.7"
-            pydantic-version: pydantic-v2
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -73,12 +66,8 @@ jobs:
       - name: Install Pydantic v2
         if: matrix.pydantic-version == 'pydantic-v2'
         run: uv pip install --upgrade "pydantic>=2.0.2,<3.0.0"
-      - name: Pin typing-extensions for Python 3.7
-        if: matrix.python-version == '3.7'
-        run: uv pip install --upgrade "typing-extensions==4.6.1"
       - name: Lint
-        # Do not run on Python 3.7 as mypy behaves differently
-        if: matrix.python-version != '3.7' && matrix.pydantic-version == 'pydantic-v2'
+        if: matrix.pydantic-version == 'pydantic-v2'
         run: bash scripts/lint.sh
       - run: mkdir coverage
       - name: Test

--- a/docs/tutorial/automatic-id-none-refresh.md
+++ b/docs/tutorial/automatic-id-none-refresh.md
@@ -342,7 +342,7 @@ And as we created the **engine** with `echo=True`, we can see the SQL statements
 
 ////
 
-//// tab | Python 3.7+
+//// tab | Python 3.8+
 
 ```Python
 {!./docs_src/tutorial/automatic_id_none_refresh/tutorial002.py!}

--- a/docs/tutorial/create-db-and-table.md
+++ b/docs/tutorial/create-db-and-table.md
@@ -562,7 +562,7 @@ Now, let's give the code a final look:
 
 ////
 
-//// tab | Python 3.7+
+//// tab | Python 3.8+
 
 ```{.python .annotate}
 {!./docs_src/tutorial/create_db_and_table/tutorial003.py!}

--- a/docs/tutorial/delete.md
+++ b/docs/tutorial/delete.md
@@ -227,7 +227,7 @@ Now let's review all that code:
 
 ////
 
-//// tab | Python 3.7+
+//// tab | Python 3.8+
 
 ```{ .python .annotate hl_lines="72-90" }
 {!./docs_src/tutorial/delete/tutorial002.py!}

--- a/docs/tutorial/fastapi/tests.md
+++ b/docs/tutorial/fastapi/tests.md
@@ -356,7 +356,7 @@ Now we can run the tests with `pytest` and see the results:
 $ pytest
 
 ============= test session starts ==============
-platform linux -- Python 3.7.5, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
+platform linux -- Python 3.10.0, pytest-7.4.4, pluggy-1.5.0
 rootdir: /home/user/code/sqlmodel-tutorial
 <b>collected 7 items                              </b>
 

--- a/docs/tutorial/insert.md
+++ b/docs/tutorial/insert.md
@@ -39,7 +39,7 @@ This is the code we had to create the database and table, nothing new here:
 
 ////
 
-//// tab | Python 3.7+
+//// tab | Python 3.8+
 
 ```{.python .annotate hl_lines="22" }
 {!./docs_src/tutorial/create_db_and_table/tutorial003.py[ln:1-20]!}
@@ -343,7 +343,7 @@ Let's focus on the new code:
 
 ////
 
-//// tab | Python 3.7+
+//// tab | Python 3.8+
 
 ```{.python .annotate }
 {!./docs_src/tutorial/insert/tutorial003.py!}

--- a/docs/tutorial/select.md
+++ b/docs/tutorial/select.md
@@ -273,7 +273,7 @@ Let's review the code up to this point:
 
 ////
 
-//// tab | Python 3.7+
+//// tab | Python 3.8+
 
 ```{ .python .annotate }
 {!./docs_src/tutorial/select/tutorial002.py!}

--- a/docs/tutorial/update.md
+++ b/docs/tutorial/update.md
@@ -236,7 +236,7 @@ Now let's review all that code:
 
 ////
 
-//// tab | Python 3.7+
+//// tab | Python 3.8+
 
 ```{ .python .annotate hl_lines="44-55" }
 {!./docs_src/tutorial/update/tutorial002.py!}
@@ -272,7 +272,7 @@ This also means that you can update several fields (attributes, columns) at once
 
 ////
 
-//// tab | Python 3.7+
+//// tab | Python 3.8+
 
 ```{ .python .annotate hl_lines="15-17  19-21  23" }
 # Code above omitted 👆
@@ -296,7 +296,7 @@ This also means that you can update several fields (attributes, columns) at once
 
 ////
 
-//// tab | Python 3.7+
+//// tab | Python 3.8+
 
 ```Python
 {!./docs_src/tutorial/update/tutorial004.py!}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "sqlmodel"
 dynamic = ["version"]
 description = "SQLModel, SQL databases in Python, designed for simplicity, compatibility, and robustness."
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 authors = [
     { name = "Sebastián Ramírez", email = "tiangolo@gmail.com" },
 ]
@@ -20,7 +20,6 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -11,8 +11,7 @@ pillow==11.0.0
 # For image processing by Material for MkDocs
 cairosvg==2.7.1
 # mkdocstrings[python]==0.25.1
-# Enable griffe-typingdoc once dropping Python 3.7 and upgrading typing-extensions
-# griffe-typingdoc==0.2.5
+griffe-typingdoc==0.2.5
 # For griffe, it formats with black
 typer == 0.12.3
 mkdocs-macros-plugin==1.0.5

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -7,11 +7,6 @@ ruff ==0.9.6
 # For FastAPI tests
 fastapi >=0.103.2
 httpx ==0.24.1
-# TODO: upgrade when deprecating Python 3.7
-dirty-equals ==0.6.0; python_version < "3.8"
-dirty-equals ==0.9.0; python_version >= "3.8"
+dirty-equals ==0.9.0
 jinja2 ==3.1.4
-# Pin typing-extensions until Python 3.8 is deprecated or the issue with dirty-equals
-# is fixed, maybe fixed after dropping Python 3.7 and upgrading dirty-equals
-typing-extensions ==4.6.1; python_version < "3.8"
-typing-extensions ==4.12.2; python_version >= "3.8"
+typing-extensions ==4.12.2


### PR DESCRIPTION
Considering the fact that Python 3.8 still seem to be [used](https://pypistats.org/packages/sqlmodel) quite a lot, we're currently only removing support for Python 3.7.

This PR also enables `griffe-typingdoc`.