### PR TITLE
✨ Increase `number_of_types` to 8 to support longer select queries

### DIFF
--- a/sqlmodel/sql/_expression_select_gen.py
+++ b/sqlmodel/sql/_expression_select_gen.py
@@ -15,6 +15,7 @@ from uuid import UUID
 
 from sqlalchemy import (
     Column,
+    Label,
 )
 from sqlalchemy.sql.elements import (
     SQLCoreOperations,
@@ -40,6 +41,7 @@ _TScalar_0 = TypeVar(
     Column,  # type: ignore
     Sequence,  # type: ignore
     Mapping,  # type: ignore
+    Label,  # type: ignore
     UUID,
     datetime,
     float,
@@ -58,6 +60,7 @@ _TScalar_1 = TypeVar(
     Column,  # type: ignore
     Sequence,  # type: ignore
     Mapping,  # type: ignore
+    Label,  # type: ignore
     UUID,
     datetime,
     float,
@@ -76,6 +79,7 @@ _TScalar_2 = TypeVar(
     Column,  # type: ignore
     Sequence,  # type: ignore
     Mapping,  # type: ignore
+    Label,  # type: ignore
     UUID,
     datetime,
     float,
@@ -94,6 +98,7 @@ _TScalar_3 = TypeVar(
     Column,  # type: ignore
     Sequence,  # type: ignore
     Mapping,  # type: ignore
+    Label,  # type: ignore
     UUID,
     datetime,
     float,
@@ -116,6 +121,16 @@ def select(__ent0: _TCCA[_T0]) -> SelectOfScalar[_T0]: ...
 
 @overload
 def select(__ent0: _TScalar_0) -> SelectOfScalar[_TScalar_0]:  # type: ignore
+    ...
+
+
+@overload
+def select(*entities: _TCCA[_T0]) -> Select[Tuple[_T0, ...]]:  # type: ignore
+    ...
+
+
+@overload
+def select(*entities: _TScalar_0) -> Select[Tuple[_TScalar_0, ...]]:  # type: ignore
     ...
 
 

--- a/sqlmodel/sql/_expression_select_gen.py
+++ b/sqlmodel/sql/_expression_select_gen.py
@@ -116,7 +116,8 @@ _T3 = TypeVar("_T3")
 
 
 @overload
-def select(__ent0: _TCCA[_T0]) -> SelectOfScalar[_T0]: ...
+def select(__ent0: _TCCA[_T0]) -> SelectOfScalar[_T0]:  # type: ignore
+    ...
 
 
 @overload

--- a/sqlmodel/sql/_expression_select_gen.py.jinja2
+++ b/sqlmodel/sql/_expression_select_gen.py.jinja2
@@ -13,6 +13,7 @@ from uuid import UUID
 
 from sqlalchemy import (
     Column,
+    Label,
 )
 from sqlalchemy.sql.elements import (
     SQLCoreOperations,
@@ -39,6 +40,7 @@ _TScalar_{{ i }} = TypeVar(
     Column,  # type: ignore
     Sequence,  # type: ignore
     Mapping,  # type: ignore
+    Label, # type: ignore
     UUID,
     datetime,
     float,
@@ -61,6 +63,16 @@ def select(__ent0: _TCCA[_T0]) -> SelectOfScalar[_T0]: ...
 
 @overload
 def select(__ent0: _TScalar_0) -> SelectOfScalar[_TScalar_0]:  # type: ignore
+    ...
+
+
+@overload
+def select(*entities: _TCCA[_T0]) -> Select[Tuple[_T0, ...]]:  # type: ignore
+    ...
+
+
+@overload
+def select(*entities: _TScalar_0) -> Select[Tuple[_TScalar_0, ...]]:  # type: ignore
     ...
 
 

--- a/sqlmodel/sql/_expression_select_gen.py.jinja2
+++ b/sqlmodel/sql/_expression_select_gen.py.jinja2
@@ -58,7 +58,8 @@ _T{{ i }} = TypeVar("_T{{ i }}")
 # Generated TypeVars end
 
 @overload
-def select(__ent0: _TCCA[_T0]) -> SelectOfScalar[_T0]: ...
+def select(__ent0: _TCCA[_T0]) -> SelectOfScalar[_T0]: # type: ignore
+    ...
 
 
 @overload


### PR DESCRIPTION
I am trying to write a select statement that selects 5 different SQLModel children. However I get a type error as the overloads for select are limited to 4.

I am aware there is a [PR](https://github.com/fastapi/sqlmodel/pull/839) that adds typing for select for arbitrary length :) 
Since that one is not merged and has conflicts (I think) I thought to give you the option to stick to the original appraoch of autogenerating types in the meantime. I increased the number of types and run the script. 

Feel free to close my PR if you would rather take another approach but I think it's a quick win! 

Resolves [92](https://github.com/fastapi/sqlmodel/issues/92), [271](https://github.com/fastapi/sqlmodel/issues/271#issuecomment-2332795054)

Thank you :)