### PR TITLE
✨ Increase `number_of_types` to 5 to support longer select queries

### DIFF
--- a/scripts/generate_select.py
+++ b/scripts/generate_select.py
@@ -13,7 +13,7 @@ template_path = (
 destiny_path = Path(__file__).parent.parent / "sqlmodel/sql/_expression_select_gen.py"
 
 
-number_of_types = 4
+number_of_types = 5
 
 
 class Arg(BaseModel):

--- a/sqlmodel/sql/_expression_select_gen.py
+++ b/sqlmodel/sql/_expression_select_gen.py
@@ -107,6 +107,24 @@ _TScalar_3 = TypeVar(
 _T3 = TypeVar("_T3")
 
 
+_TScalar_4 = TypeVar(
+    "_TScalar_4",
+    Column,  # type: ignore
+    Sequence,  # type: ignore
+    Mapping,  # type: ignore
+    UUID,
+    datetime,
+    float,
+    int,
+    bool,
+    bytes,
+    str,
+    None,
+)
+
+_T4 = TypeVar("_T4")
+
+
 # Generated TypeVars end
 
 
@@ -356,6 +374,326 @@ def select(  # type: ignore
     entity_2: _TScalar_2,
     entity_3: _TScalar_3,
 ) -> Select[Tuple[_TScalar_0, _TScalar_1, _TScalar_2, _TScalar_3]]: ...
+
+
+@overload
+def select(  # type: ignore
+    __ent0: _TCCA[_T0],
+    __ent1: _TCCA[_T1],
+    __ent2: _TCCA[_T2],
+    __ent3: _TCCA[_T3],
+    __ent4: _TCCA[_T4],
+) -> Select[Tuple[_T0, _T1, _T2, _T3, _T4]]: ...
+
+
+@overload
+def select(  # type: ignore
+    __ent0: _TCCA[_T0],
+    __ent1: _TCCA[_T1],
+    __ent2: _TCCA[_T2],
+    __ent3: _TCCA[_T3],
+    entity_4: _TScalar_4,
+) -> Select[Tuple[_T0, _T1, _T2, _T3, _TScalar_4]]: ...
+
+
+@overload
+def select(  # type: ignore
+    __ent0: _TCCA[_T0],
+    __ent1: _TCCA[_T1],
+    __ent2: _TCCA[_T2],
+    entity_3: _TScalar_3,
+    __ent4: _TCCA[_T4],
+) -> Select[Tuple[_T0, _T1, _T2, _TScalar_3, _T4]]: ...
+
+
+@overload
+def select(  # type: ignore
+    __ent0: _TCCA[_T0],
+    __ent1: _TCCA[_T1],
+    __ent2: _TCCA[_T2],
+    entity_3: _TScalar_3,
+    entity_4: _TScalar_4,
+) -> Select[Tuple[_T0, _T1, _T2, _TScalar_3, _TScalar_4]]: ...
+
+
+@overload
+def select(  # type: ignore
+    __ent0: _TCCA[_T0],
+    __ent1: _TCCA[_T1],
+    entity_2: _TScalar_2,
+    __ent3: _TCCA[_T3],
+    __ent4: _TCCA[_T4],
+) -> Select[Tuple[_T0, _T1, _TScalar_2, _T3, _T4]]: ...
+
+
+@overload
+def select(  # type: ignore
+    __ent0: _TCCA[_T0],
+    __ent1: _TCCA[_T1],
+    entity_2: _TScalar_2,
+    __ent3: _TCCA[_T3],
+    entity_4: _TScalar_4,
+) -> Select[Tuple[_T0, _T1, _TScalar_2, _T3, _TScalar_4]]: ...
+
+
+@overload
+def select(  # type: ignore
+    __ent0: _TCCA[_T0],
+    __ent1: _TCCA[_T1],
+    entity_2: _TScalar_2,
+    entity_3: _TScalar_3,
+    __ent4: _TCCA[_T4],
+) -> Select[Tuple[_T0, _T1, _TScalar_2, _TScalar_3, _T4]]: ...
+
+
+@overload
+def select(  # type: ignore
+    __ent0: _TCCA[_T0],
+    __ent1: _TCCA[_T1],
+    entity_2: _TScalar_2,
+    entity_3: _TScalar_3,
+    entity_4: _TScalar_4,
+) -> Select[Tuple[_T0, _T1, _TScalar_2, _TScalar_3, _TScalar_4]]: ...
+
+
+@overload
+def select(  # type: ignore
+    __ent0: _TCCA[_T0],
+    entity_1: _TScalar_1,
+    __ent2: _TCCA[_T2],
+    __ent3: _TCCA[_T3],
+    __ent4: _TCCA[_T4],
+) -> Select[Tuple[_T0, _TScalar_1, _T2, _T3, _T4]]: ...
+
+
+@overload
+def select(  # type: ignore
+    __ent0: _TCCA[_T0],
+    entity_1: _TScalar_1,
+    __ent2: _TCCA[_T2],
+    __ent3: _TCCA[_T3],
+    entity_4: _TScalar_4,
+) -> Select[Tuple[_T0, _TScalar_1, _T2, _T3, _TScalar_4]]: ...
+
+
+@overload
+def select(  # type: ignore
+    __ent0: _TCCA[_T0],
+    entity_1: _TScalar_1,
+    __ent2: _TCCA[_T2],
+    entity_3: _TScalar_3,
+    __ent4: _TCCA[_T4],
+) -> Select[Tuple[_T0, _TScalar_1, _T2, _TScalar_3, _T4]]: ...
+
+
+@overload
+def select(  # type: ignore
+    __ent0: _TCCA[_T0],
+    entity_1: _TScalar_1,
+    __ent2: _TCCA[_T2],
+    entity_3: _TScalar_3,
+    entity_4: _TScalar_4,
+) -> Select[Tuple[_T0, _TScalar_1, _T2, _TScalar_3, _TScalar_4]]: ...
+
+
+@overload
+def select(  # type: ignore
+    __ent0: _TCCA[_T0],
+    entity_1: _TScalar_1,
+    entity_2: _TScalar_2,
+    __ent3: _TCCA[_T3],
+    __ent4: _TCCA[_T4],
+) -> Select[Tuple[_T0, _TScalar_1, _TScalar_2, _T3, _T4]]: ...
+
+
+@overload
+def select(  # type: ignore
+    __ent0: _TCCA[_T0],
+    entity_1: _TScalar_1,
+    entity_2: _TScalar_2,
+    __ent3: _TCCA[_T3],
+    entity_4: _TScalar_4,
+) -> Select[Tuple[_T0, _TScalar_1, _TScalar_2, _T3, _TScalar_4]]: ...
+
+
+@overload
+def select(  # type: ignore
+    __ent0: _TCCA[_T0],
+    entity_1: _TScalar_1,
+    entity_2: _TScalar_2,
+    entity_3: _TScalar_3,
+    __ent4: _TCCA[_T4],
+) -> Select[Tuple[_T0, _TScalar_1, _TScalar_2, _TScalar_3, _T4]]: ...
+
+
+@overload
+def select(  # type: ignore
+    __ent0: _TCCA[_T0],
+    entity_1: _TScalar_1,
+    entity_2: _TScalar_2,
+    entity_3: _TScalar_3,
+    entity_4: _TScalar_4,
+) -> Select[Tuple[_T0, _TScalar_1, _TScalar_2, _TScalar_3, _TScalar_4]]: ...
+
+
+@overload
+def select(  # type: ignore
+    entity_0: _TScalar_0,
+    __ent1: _TCCA[_T1],
+    __ent2: _TCCA[_T2],
+    __ent3: _TCCA[_T3],
+    __ent4: _TCCA[_T4],
+) -> Select[Tuple[_TScalar_0, _T1, _T2, _T3, _T4]]: ...
+
+
+@overload
+def select(  # type: ignore
+    entity_0: _TScalar_0,
+    __ent1: _TCCA[_T1],
+    __ent2: _TCCA[_T2],
+    __ent3: _TCCA[_T3],
+    entity_4: _TScalar_4,
+) -> Select[Tuple[_TScalar_0, _T1, _T2, _T3, _TScalar_4]]: ...
+
+
+@overload
+def select(  # type: ignore
+    entity_0: _TScalar_0,
+    __ent1: _TCCA[_T1],
+    __ent2: _TCCA[_T2],
+    entity_3: _TScalar_3,
+    __ent4: _TCCA[_T4],
+) -> Select[Tuple[_TScalar_0, _T1, _T2, _TScalar_3, _T4]]: ...
+
+
+@overload
+def select(  # type: ignore
+    entity_0: _TScalar_0,
+    __ent1: _TCCA[_T1],
+    __ent2: _TCCA[_T2],
+    entity_3: _TScalar_3,
+    entity_4: _TScalar_4,
+) -> Select[Tuple[_TScalar_0, _T1, _T2, _TScalar_3, _TScalar_4]]: ...
+
+
+@overload
+def select(  # type: ignore
+    entity_0: _TScalar_0,
+    __ent1: _TCCA[_T1],
+    entity_2: _TScalar_2,
+    __ent3: _TCCA[_T3],
+    __ent4: _TCCA[_T4],
+) -> Select[Tuple[_TScalar_0, _T1, _TScalar_2, _T3, _T4]]: ...
+
+
+@overload
+def select(  # type: ignore
+    entity_0: _TScalar_0,
+    __ent1: _TCCA[_T1],
+    entity_2: _TScalar_2,
+    __ent3: _TCCA[_T3],
+    entity_4: _TScalar_4,
+) -> Select[Tuple[_TScalar_0, _T1, _TScalar_2, _T3, _TScalar_4]]: ...
+
+
+@overload
+def select(  # type: ignore
+    entity_0: _TScalar_0,
+    __ent1: _TCCA[_T1],
+    entity_2: _TScalar_2,
+    entity_3: _TScalar_3,
+    __ent4: _TCCA[_T4],
+) -> Select[Tuple[_TScalar_0, _T1, _TScalar_2, _TScalar_3, _T4]]: ...
+
+
+@overload
+def select(  # type: ignore
+    entity_0: _TScalar_0,
+    __ent1: _TCCA[_T1],
+    entity_2: _TScalar_2,
+    entity_3: _TScalar_3,
+    entity_4: _TScalar_4,
+) -> Select[Tuple[_TScalar_0, _T1, _TScalar_2, _TScalar_3, _TScalar_4]]: ...
+
+
+@overload
+def select(  # type: ignore
+    entity_0: _TScalar_0,
+    entity_1: _TScalar_1,
+    __ent2: _TCCA[_T2],
+    __ent3: _TCCA[_T3],
+    __ent4: _TCCA[_T4],
+) -> Select[Tuple[_TScalar_0, _TScalar_1, _T2, _T3, _T4]]: ...
+
+
+@overload
+def select(  # type: ignore
+    entity_0: _TScalar_0,
+    entity_1: _TScalar_1,
+    __ent2: _TCCA[_T2],
+    __ent3: _TCCA[_T3],
+    entity_4: _TScalar_4,
+) -> Select[Tuple[_TScalar_0, _TScalar_1, _T2, _T3, _TScalar_4]]: ...
+
+
+@overload
+def select(  # type: ignore
+    entity_0: _TScalar_0,
+    entity_1: _TScalar_1,
+    __ent2: _TCCA[_T2],
+    entity_3: _TScalar_3,
+    __ent4: _TCCA[_T4],
+) -> Select[Tuple[_TScalar_0, _TScalar_1, _T2, _TScalar_3, _T4]]: ...
+
+
+@overload
+def select(  # type: ignore
+    entity_0: _TScalar_0,
+    entity_1: _TScalar_1,
+    __ent2: _TCCA[_T2],
+    entity_3: _TScalar_3,
+    entity_4: _TScalar_4,
+) -> Select[Tuple[_TScalar_0, _TScalar_1, _T2, _TScalar_3, _TScalar_4]]: ...
+
+
+@overload
+def select(  # type: ignore
+    entity_0: _TScalar_0,
+    entity_1: _TScalar_1,
+    entity_2: _TScalar_2,
+    __ent3: _TCCA[_T3],
+    __ent4: _TCCA[_T4],
+) -> Select[Tuple[_TScalar_0, _TScalar_1, _TScalar_2, _T3, _T4]]: ...
+
+
+@overload
+def select(  # type: ignore
+    entity_0: _TScalar_0,
+    entity_1: _TScalar_1,
+    entity_2: _TScalar_2,
+    __ent3: _TCCA[_T3],
+    entity_4: _TScalar_4,
+) -> Select[Tuple[_TScalar_0, _TScalar_1, _TScalar_2, _T3, _TScalar_4]]: ...
+
+
+@overload
+def select(  # type: ignore
+    entity_0: _TScalar_0,
+    entity_1: _TScalar_1,
+    entity_2: _TScalar_2,
+    entity_3: _TScalar_3,
+    __ent4: _TCCA[_T4],
+) -> Select[Tuple[_TScalar_0, _TScalar_1, _TScalar_2, _TScalar_3, _T4]]: ...
+
+
+@overload
+def select(  # type: ignore
+    entity_0: _TScalar_0,
+    entity_1: _TScalar_1,
+    entity_2: _TScalar_2,
+    entity_3: _TScalar_3,
+    entity_4: _TScalar_4,
+) -> Select[Tuple[_TScalar_0, _TScalar_1, _TScalar_2, _TScalar_3, _TScalar_4]]: ...
 
 
 # Generated overloads end


### PR DESCRIPTION
I am trying to write a select statement that selects 5 different SQLModel children. However I get a type error as the overloads for select are limited to 4.

Increasing to 6+ causes `mypy` to hang, so I chose 5 :)

Resolves https://github.com/fastapi/sqlmodel/issues/271#issuecomment-2332795054

Thank you very much for your time and working on OSS!