### PR TITLE
Make field's description interpret as column's comment

### DIFF
--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -744,6 +744,9 @@ def get_column_from_field(field: Any) -> Column:  # type: ignore
         "index": index,
         "unique": unique,
     }
+    description = getattr(field_info, "description", Undefined)
+    if description is not Undefined:
+        kwargs["comment"] = description
     sa_default = Undefined
     if field_info.default_factory:
         sa_default = field_info.default_factory

--- a/tests/test_field_description.py
+++ b/tests/test_field_description.py
@@ -1,0 +1,23 @@
+from pytest import LogCaptureFixture
+from sqlmodel import Field, SQLModel, create_engine
+
+
+def test_sa_column_description(clear_sqlmodel: None, caplog: LogCaptureFixture) -> None:
+    class Team(SQLModel, table=True):
+        id: int = Field(primary_key=True, description="an id")
+        name: str = Field(description="a name")
+        age: int = Field()
+
+    assert Team.model_fields["id"].description == "an id"
+    assert Team.model_fields["name"].description == "a name"
+    assert Team.model_fields["age"].description is None
+
+    engine = create_engine("sqlite://", echo=True)  # TODO: this should go to Postgres
+    SQLModel.metadata.create_all(engine)
+    msgs = []
+    for msg in caplog.messages:
+        if "COMMENT ON COLUMN" in msg:
+            msgs.append(msg)
+    assert len(msgs) == 2
+    assert "COMMENT ON COLUMN team.id IS 'an id'" in msgs[0]
+    assert "COMMENT ON COLUMN team.name IS 'a name'" in msgs[1]


### PR DESCRIPTION
I have fields with `description` attributes I'd like to use as `comment`s on columns in Postgresql tables.

All tests in sqlmodel use sqlite that does not support column comments. So my test in this PR does not work. What would be the best way to test it for Postgres (and other RDBMs supporting column comments)?

When I locally replace the `sqlite://` with a proper Postgresql connect string to my local database, the test passes.

There's #1293, but also without working test.