### PR TITLE
Add IntEnum for sqltypes

### DIFF
--- a/sqlmodel/__init__.py
+++ b/sqlmodel/__init__.py
@@ -141,3 +141,4 @@ from .sql.expression import tuple_ as tuple_
 from .sql.expression import type_coerce as type_coerce
 from .sql.expression import within_group as within_group
 from .sql.sqltypes import AutoString as AutoString
+from .sql.sqltypes import IntEnum as IntEnum

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -63,14 +63,21 @@ def test_json_schema_flat_model_pydantic_v1():
         "properties": {
             "id": {"title": "Id", "type": "string", "format": "uuid"},
             "enum_field": {"$ref": "#/definitions/MyEnum1"},
+            "int_enum_field": {"$ref": "#/definitions/MyEnum3"},
         },
-        "required": ["id", "enum_field"],
+        "required": ["id", "enum_field", "int_enum_field"],
         "definitions": {
             "MyEnum1": {
                 "title": "MyEnum1",
                 "description": "An enumeration.",
                 "enum": ["A", "B"],
                 "type": "string",
+            },
+            "MyEnum3": {
+                "title": "MyEnum3",
+                "description": "An enumeration.",
+                "enum": [1, 3],
+                "type": "int",
             }
         },
     }
@@ -84,14 +91,21 @@ def test_json_schema_inherit_model_pydantic_v1():
         "properties": {
             "id": {"title": "Id", "type": "string", "format": "uuid"},
             "enum_field": {"$ref": "#/definitions/MyEnum2"},
+            "int_enum_field": {"$ref": "#/definitions/MyEnum3"},
         },
-        "required": ["id", "enum_field"],
+        "required": ["id", "enum_field", "int_enum_field"],
         "definitions": {
             "MyEnum2": {
                 "title": "MyEnum2",
                 "description": "An enumeration.",
                 "enum": ["C", "D"],
                 "type": "string",
+            },
+            "MyEnum3": {
+                "title": "MyEnum3",
+                "description": "An int enumeration.",
+                "enum": [1, 3],
+                "type": "int",
             }
         },
     }
@@ -105,10 +119,12 @@ def test_json_schema_flat_model_pydantic_v2():
         "properties": {
             "id": {"title": "Id", "type": "string", "format": "uuid"},
             "enum_field": {"$ref": "#/$defs/MyEnum1"},
+            "int_enum_field": {"$ref": "#/$defs/MyEnum3"},
         },
-        "required": ["id", "enum_field"],
+        "required": ["id", "enum_field", "int_enum_field"],
         "$defs": {
-            "MyEnum1": {"enum": ["A", "B"], "title": "MyEnum1", "type": "string"}
+            "MyEnum1": {"enum": ["A", "B"], "title": "MyEnum1", "type": "string"},
+            "MyEnum3": {"enum": [1, 2], "title": "MyEnum3", "type": "integer"},
         },
     }
 
@@ -121,9 +137,11 @@ def test_json_schema_inherit_model_pydantic_v2():
         "properties": {
             "id": {"title": "Id", "type": "string", "format": "uuid"},
             "enum_field": {"$ref": "#/$defs/MyEnum2"},
+            "int_enum_field": {"$ref": "#/$defs/MyEnum3"},
         },
-        "required": ["id", "enum_field"],
+        "required": ["id", "enum_field", "int_enum_field"],
         "$defs": {
-            "MyEnum2": {"enum": ["C", "D"], "title": "MyEnum2", "type": "string"}
+            "MyEnum2": {"enum": ["C", "D"], "title": "MyEnum2", "type": "string"},
+            "MyEnum3": {"enum": [1, 2], "title": "MyEnum3", "type": "integer"},
         },
     }

--- a/tests/test_enums_models.py
+++ b/tests/test_enums_models.py
@@ -1,7 +1,7 @@
 import enum
 import uuid
 
-from sqlmodel import Field, SQLModel
+from sqlmodel import Field, SQLModel, IntEnum
 
 
 class MyEnum1(str, enum.Enum):
@@ -13,15 +13,19 @@ class MyEnum2(str, enum.Enum):
     C = "C"
     D = "D"
 
+class MyEnum3(enum.IntEnum):
+    E = 1
+    F = 2
 
 class BaseModel(SQLModel):
     id: uuid.UUID = Field(primary_key=True)
     enum_field: MyEnum2
-
+    int_enum_field: MyEnum3
 
 class FlatModel(SQLModel, table=True):
     id: uuid.UUID = Field(primary_key=True)
     enum_field: MyEnum1
+    int_enum_field: MyEnum3 = Field(sa_type=IntEnum(MyEnum3))
 
 
 class InheritModel(BaseModel, table=True):


### PR DESCRIPTION
I add a IntEnum type decorator which I used in my private project.

I wish it helps!

```python
from enum import IntEnum
class HeroStatus(IntEnum):
    ACTIVE = 1
    DISABLE = 2    

from sqlmodel import IntEnum
class Hero(SQLModel):
    hero_status: HeroStatus = Field(sa_type=IntEnum(HeroStatus))


user.hero_status == Status.ACTIVE      # Loads back as enum

```