### PR TITLE
💚 Fix linting in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
         if: matrix.pydantic-version == 'pydantic-v2'
         run: uv pip install --upgrade "pydantic>=2.0.2,<3.0.0"
       - name: Lint
-        if: matrix.pydantic-version == 'pydantic-v2'
+        if: matrix.pydantic-version == 'pydantic-v2' && matrix.python-version != '3.8'
         run: bash scripts/lint.sh
       - run: mkdir coverage
       - name: Test

--- a/sqlmodel/_compat.py
+++ b/sqlmodel/_compat.py
@@ -103,7 +103,7 @@ if IS_PYDANTIC_V2:
         model.model_config[parameter] = value  # type: ignore[literal-required]
 
     def get_model_fields(model: InstanceOrType[BaseModel]) -> Dict[str, "FieldInfo"]:
-        return model.model_fields
+        return model.model_fields  # type: ignore[arg-type]
 
     def get_fields_set(
         object: InstanceOrType["SQLModel"],

--- a/sqlmodel/_compat.py
+++ b/sqlmodel/_compat.py
@@ -103,7 +103,14 @@ if IS_PYDANTIC_V2:
         model.model_config[parameter] = value  # type: ignore[literal-required]
 
     def get_model_fields(model: InstanceOrType[BaseModel]) -> Dict[str, "FieldInfo"]:
-        return model.model_fields  # type: ignore[arg-type]
+        # TODO: refactor the usage of this function to always pass the class
+        # not the instance, and then remove this extra check
+        # this is for compatibility with Pydantic v3
+        if isinstance(model, type):
+            use_model = model
+        else:
+            use_model = model.__class__
+        return use_model.model_fields
 
     def get_fields_set(
         object: InstanceOrType["SQLModel"],

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -839,16 +839,15 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
         return cls.__name__.lower()
 
     @classmethod
-    def model_validate(
+    def model_validate(  # type: ignore[override]
         cls: Type[_TSQLModel],
         obj: Any,
         *,
         strict: Union[bool, None] = None,
         from_attributes: Union[bool, None] = None,
         context: Union[Dict[str, Any], None] = None,
-        **kwargs: Any,
+        update: Union[Dict[str, Any], None] = None,
     ) -> _TSQLModel:
-        update = kwargs.get("update", None)
         return sqlmodel_validate(
             cls=cls,
             obj=obj,
@@ -865,16 +864,15 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
         include: Union[IncEx, None] = None,
         exclude: Union[IncEx, None] = None,
         context: Union[Any, None] = None,
-        by_alias: Union[bool, None] = False,
+        by_alias: Union[bool, None] = None,
         exclude_unset: bool = False,
         exclude_defaults: bool = False,
         exclude_none: bool = False,
         round_trip: bool = False,
         warnings: Union[bool, Literal["none", "warn", "error"]] = True,
+        fallback: Callable[[Any], Any] | None = None,
         serialize_as_any: bool = False,
-        **kwargs: Any,
     ) -> Dict[str, Any]:
-        fallback = kwargs.get("fallback", None)
         if PYDANTIC_MINOR_VERSION >= (2, 7):
             extra_kwargs: Dict[str, Any] = {
                 "context": context,
@@ -899,11 +897,10 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
                 **extra_kwargs,
             )
         else:
-            assert by_alias is not None
             return super().dict(
                 include=include,
                 exclude=exclude,
-                by_alias=by_alias,
+                by_alias=by_alias or False,
                 exclude_unset=exclude_unset,
                 exclude_defaults=exclude_defaults,
                 exclude_none=exclude_none,

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -477,7 +477,7 @@ def Relationship(
 class SQLModelMetaclass(ModelMetaclass, DeclarativeMeta):
     __sqlmodel_relationships__: Dict[str, RelationshipInfo]
     model_config: SQLModelConfig
-    model_fields: Dict[str, FieldInfo]
+    model_fields: ClassVar[Dict[str, FieldInfo]]
     __config__: Type[SQLModelConfig]
     __fields__: Dict[str, ModelField]  # type: ignore[assignment]
 

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -846,8 +846,9 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
         strict: Union[bool, None] = None,
         from_attributes: Union[bool, None] = None,
         context: Union[Dict[str, Any], None] = None,
-        update: Union[Dict[str, Any], None] = None,
+        **kwargs: Any,
     ) -> _TSQLModel:
+        update = kwargs.get("update", None)
         return sqlmodel_validate(
             cls=cls,
             obj=obj,

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -873,6 +873,8 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
         fallback: Union[Callable[[Any], Any], None] = None,
         serialize_as_any: bool = False,
     ) -> Dict[str, Any]:
+        if PYDANTIC_MINOR_VERSION < (2, 11):
+            by_alias = by_alias or False
         if PYDANTIC_MINOR_VERSION >= (2, 7):
             extra_kwargs: Dict[str, Any] = {
                 "context": context,
@@ -880,7 +882,6 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
             }
         if PYDANTIC_MINOR_VERSION >= (2, 11):
             extra_kwargs["fallback"] = fallback
-
         else:
             extra_kwargs = {}
         if IS_PYDANTIC_V2:

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -871,15 +871,18 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
         exclude_none: bool = False,
         round_trip: bool = False,
         warnings: Union[bool, Literal["none", "warn", "error"]] = True,
-        fallback: Union[Callable[[Any], Any], None] = None,
         serialize_as_any: bool = False,
+        **kwargs: Any,
     ) -> Dict[str, Any]:
+        fallback = kwargs.get("fallback", None)
         if PYDANTIC_MINOR_VERSION >= (2, 7):
             extra_kwargs: Dict[str, Any] = {
                 "context": context,
                 "serialize_as_any": serialize_as_any,
-                "fallback": fallback,
             }
+        if PYDANTIC_MINOR_VERSION >= (2, 11):
+            extra_kwargs["fallback"] = fallback
+
         else:
             extra_kwargs = {}
         if IS_PYDANTIC_V2:

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -477,7 +477,7 @@ def Relationship(
 class SQLModelMetaclass(ModelMetaclass, DeclarativeMeta):
     __sqlmodel_relationships__: Dict[str, RelationshipInfo]
     model_config: SQLModelConfig
-    model_fields: Dict[str, FieldInfo]  # type: ignore[assignment]
+    model_fields: Dict[str, FieldInfo]
     __config__: Type[SQLModelConfig]
     __fields__: Dict[str, ModelField]  # type: ignore[assignment]
 

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -864,19 +864,21 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
         mode: Union[Literal["json", "python"], str] = "python",
         include: Union[IncEx, None] = None,
         exclude: Union[IncEx, None] = None,
-        context: Union[Dict[str, Any], None] = None,
-        by_alias: bool = False,
+        context: Union[Any, None] = None,
+        by_alias: Union[bool, None] = False,
         exclude_unset: bool = False,
         exclude_defaults: bool = False,
         exclude_none: bool = False,
         round_trip: bool = False,
         warnings: Union[bool, Literal["none", "warn", "error"]] = True,
+        fallback: Union[Callable[[Any], Any], None] = None,
         serialize_as_any: bool = False,
     ) -> Dict[str, Any]:
         if PYDANTIC_MINOR_VERSION >= (2, 7):
             extra_kwargs: Dict[str, Any] = {
                 "context": context,
                 "serialize_as_any": serialize_as_any,
+                "fallback": fallback,
             }
         else:
             extra_kwargs = {}
@@ -894,6 +896,7 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
                 **extra_kwargs,
             )
         else:
+            assert by_alias is not None
             return super().dict(
                 include=include,
                 exclude=exclude,

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -870,7 +870,7 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
         exclude_none: bool = False,
         round_trip: bool = False,
         warnings: Union[bool, Literal["none", "warn", "error"]] = True,
-        fallback: Callable[[Any], Any] | None = None,
+        fallback: Union[Callable[[Any], Any], None] = None,
         serialize_as_any: bool = False,
     ) -> Dict[str, Any]:
         if PYDANTIC_MINOR_VERSION >= (2, 7):


### PR DESCRIPTION
Recent PRs have been failing due to an issue with the linting step in the CI - I think caused by the recent release of Pydantic 2.11.

Overview of issues and proposed fixes:

- Elaborate type warning for `get_model_fields` in `_compat.py`. 
```
sqlmodel/_compat.py:106: error: Argument 1 to "__get__" of "deprecated_instance_property" has incompatible type "BaseModel | type[BaseModel]"; expected "BaseModel"  [arg-type]
sqlmodel/_compat.py:106: error: Argument 2 to "__get__" of "deprecated_instance_property" has incompatible type "type[BaseModel] | type[type[BaseModel]]"; expected "type[BaseModel]"  [arg-type]
```
I think it's fine to ignore this one?

- `model_fields` in `SQLModelMetaclass` on the other hand, now can do without an ignore warning
- `SQLModel.model_validate()` is supposed to overwrite `BaseModel.model_validate()` but an error gets raised because of the `update` input parameter, which is not present in `BaseModel.model_validate()`. The proposed solution here is to work via `**kwargs`, which I'm generally not a fan of, but the only other option I would see is adding yet another ignore, which feels wrong in this case.
- `SQLModel.model_dump()` is supposed to overwrite `BaseModel.model_dump()` but an error gets raised because of `context` and `alias` having a wrong type, and `fallback` not being present. `fallback` was [introduced](https://github.com/pydantic/pydantic/pull/11398) in Pydantic v2.11. So instead of restricting Pydantic, I suggest to (again) work via `**kwargs`.

The linting test is failing for Python 3.8 in different ways than for all other Python versions, probably because Python 3.8 support was [removed](https://github.com/pydantic/pydantic/pull/11258) for Pydantic 2.11. Accordingly, I've updated the `test.yml` to skip the linting test for Python 3.8. This doesn't feel like a clean solution either, and I guess the other option is to (also) drop support for Python 3.8.