### PR TITLE
Update relationships.md

### DIFF
--- a/docs/tutorial/fastapi/relationships.md
+++ b/docs/tutorial/fastapi/relationships.md
@@ -166,7 +166,7 @@ This will tell **FastAPI** to take the object that we return from the *path oper
 
 In the case of the hero, this tells FastAPI to extract the `team` too. And in the case of the team, to extract the list of `heroes` too.
 
-{* ./docs_src/tutorial/fastapi/relationships/tutorial001_py310.py ln[111:116,165:170] hl[111,116,165,170] *}
+{* ./docs_src/tutorial/fastapi/relationships/tutorial001_py310.py ln[111:116,165:170] hl[111,116,164,169] *}
 
 ## Check It Out in the Docs UI
 


### PR DESCRIPTION
# Fixed Incorrect Line Highlights in FastAPI Relationships Tutorial

I fixed the incorrect line highlights in the FastAPI relationships tutorial documentation. The highlighted lines were incorrectly pointing to lines 165 and 170, which should actually be lines 164 and 169.

## Issue Details

The highlighted lines for methods related to teams were not correctly aligned with the intended code sections that showcase the newly introduced `TeamPublicWithHeroes` class. This misalignment could cause confusion for users following the tutorial.

Note that the highlighted line numbers for methods related to heroes were already correct, properly highlighting the `HeroPublicWithTeam` class.

## Changes Made

- Changed highlight parameters from `hl[111,116,165,170]` to `hl[111,116,164,169]`
- The first pair (111,116) remains unchanged as it was correct
- The second pair was corrected from (165,170) to (164,169)

## Before Fix

![image](https://github.com/user-attachments/assets/bf34d6e7-2721-46ff-911f-bd090aa14306)  
![image](https://github.com/user-attachments/assets/9627779e-a1cb-4acf-a076-5edf034ff97f)

This change ensures that the documentation accurately highlights the relevant code sections, making the tutorial easier to follow.