### PR TITLE
Pydantic 'alias' bug

### DIFF
--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -387,6 +387,11 @@ def Field(
     schema_extra: Optional[Dict[str, Any]] = None,
 ) -> Any:
     current_schema_extra = schema_extra or {}
+
+    if alias:
+        current_schema_extra['validation_alias'] = alias
+        current_schema_extra['serialization_alias'] = alias
+        
     field_info = FieldInfo(
         default,
         default_factory=default_factory,


### PR DESCRIPTION
This workaround fixes Pydantic serialization/deserialization while not modifying the internal alias logic. I cannot figure out why alias is not being passed through anymore.

For example, I was needing to add schema_extra with these key values in order to read/write data from a Json with different field names. I had similar issues to issue #290 

https://docs.pydantic.dev/latest/concepts/fields/#field-aliases
https://github.com/fastapi/sqlmodel/issues/290

Thank you for your consideration.