### PR TITLE
Add check for Literal type annotation in get_sqlalchemy_type

### DIFF
--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -655,6 +655,9 @@ def get_sqlalchemy_type(field: Any) -> Any:
     type_ = get_sa_type_from_field(field)
     metadata = get_field_metadata(field)
 
+    # Checks for `Literal` type annotation
+    if type_ is Literal:
+        return AutoString
     # Check enums first as an enum can also be a str, needed by Pydantic/FastAPI
     if issubclass(type_, Enum):
         return sa_Enum(type_)


### PR DESCRIPTION
This PR addresses [issue 57](https://github.com/fastapi/sqlmodel/issues/57). The original issue explains that attempting to use a Literal type annotation in a SQLModel raises a type error from `issubclass`. This is because `Literal` is not a class, but a [typing._SpecialForm](https://typing.python.org/en/latest/spec/glossary.html#term-special-form), so static funcs like `isinstance` and `issubclass` don't work with it. 

The fix was pretty straightforward, I just added a check before an `isinstance` or `issubclass` would have been called that checks `if type_ is Literal`.