### PR TITLE
👷 Detect and label merge conflicts on PRs automatically

### DIFF
--- a/.github/workflows/detect-conflicts.yml
+++ b/.github/workflows/detect-conflicts.yml
@@ -1,0 +1,19 @@
+name: "Conflict detector"
+on:
+  push:
+  pull_request_target:
+    types: [synchronize]
+
+jobs:
+  main:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if PRs have merge conflicts
+        uses: eps1lon/actions-label-merge-conflict@v3
+        with:
+          dirtyLabel: "conflicts"
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          commentOnDirty: "This pull request has a merge conflict that needs to be resolved."


### PR DESCRIPTION
- Label a PR that has merge conflicts with the new label "conflicts"
- Add a comment to the PR to alert the original poster & any subscribers to the thread
- Remove the label again when the conflict is resolved (but add no further comment)