### PR TITLE
🐛 Fix attribute handling in `model_dump` for compatibility with the latest Pydantic versions

### DIFF
--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -863,27 +863,24 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
         mode: Union[Literal["json", "python"], str] = "python",
         include: Union[IncEx, None] = None,
         exclude: Union[IncEx, None] = None,
-        context: Union[Any, None] = None,
+        context: Union[Any, None] = None,  # v2.7
         by_alias: Union[bool, None] = None,
         exclude_unset: bool = False,
         exclude_defaults: bool = False,
         exclude_none: bool = False,
         round_trip: bool = False,
         warnings: Union[bool, Literal["none", "warn", "error"]] = True,
-        fallback: Union[Callable[[Any], Any], None] = None,
-        serialize_as_any: bool = False,
+        fallback: Union[Callable[[Any], Any], None] = None,  # v2.11
+        serialize_as_any: bool = False,  # v2.7
     ) -> Dict[str, Any]:
         if PYDANTIC_MINOR_VERSION < (2, 11):
             by_alias = by_alias or False
+        extra_kwargs: Dict[str, Any] = {}
         if PYDANTIC_MINOR_VERSION >= (2, 7):
-            extra_kwargs: Dict[str, Any] = {
-                "context": context,
-                "serialize_as_any": serialize_as_any,
-            }
+            extra_kwargs["context"] = context
+            extra_kwargs["serialize_as_any"] = serialize_as_any
         if PYDANTIC_MINOR_VERSION >= (2, 11):
             extra_kwargs["fallback"] = fallback
-        else:
-            extra_kwargs = {}
         if IS_PYDANTIC_V2:
             return super().model_dump(
                 mode=mode,

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -109,7 +109,8 @@ def __dataclass_transform__(
     return lambda a: a
 
 
-class FieldInfo(PydanticFieldInfo):
+class FieldInfo(PydanticFieldInfo):  # type: ignore[misc]
+    # mypy - ignore that PydanticFieldInfo is @final
     def __init__(self, default: Any = Undefined, **kwargs: Any) -> None:
         primary_key = kwargs.pop("primary_key", False)
         nullable = kwargs.pop("nullable", Undefined)

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -869,6 +869,7 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
         exclude_unset: bool = False,
         exclude_defaults: bool = False,
         exclude_none: bool = False,
+        exclude_computed_fields: bool = False,  # v2.12
         round_trip: bool = False,
         warnings: Union[bool, Literal["none", "warn", "error"]] = True,
         fallback: Union[Callable[[Any], Any], None] = None,  # v2.11
@@ -882,6 +883,8 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
             extra_kwargs["serialize_as_any"] = serialize_as_any
         if PYDANTIC_MINOR_VERSION >= (2, 11):
             extra_kwargs["fallback"] = fallback
+        if PYDANTIC_MINOR_VERSION >= (2, 12):
+            extra_kwargs["exclude_computed_fields"] = exclude_computed_fields
         if IS_PYDANTIC_V2:
             return super().model_dump(
                 mode=mode,


### PR DESCRIPTION
+ ✏️   Fix reversion in model_dump attribute handling for pydantic v2.7 .. v2.10
    + The `else` block added to fix linting errors (4b5ad42) for #1340 was obliterating the `'context'` and `'serialize_as_any'` attributes for versions >= 2.7 and < 2.11.
    + Fix by initializing `extra_kwargs` and then setting on a per-version level
+  💚 Fix linting from overriding `@final` FieldInfo
+  💚 Add `exclude_computed_fields` from pydantic 2.12
    + match the upstream interface to avoid mypy linting warning.
    + pydantic added exclude_computed_fields in pydantic/pydantic-core#1780
