### PR TITLE
Enable the usage of newtypes in annotations

### DIFF
--- a/sqlmodel/_compat.py
+++ b/sqlmodel/_compat.py
@@ -171,10 +171,17 @@ def is_field_noneable(field: "FieldInfo") -> bool:
     return False
 
 
+def unwrap_newtype(tp: Any) -> Any:
+    # returns wrapped type of newtype recursivly
+    while hasattr(tp, "__supertype__"):
+        tp = tp.__supertype__
+    return tp
+
 def get_sa_type_from_type_annotation(annotation: Any) -> Any:
     # Resolve Optional fields
     if annotation is None:
         raise ValueError("Missing field type")
+    annotation = unwrap_newtype(annotation)
     origin = get_origin(annotation)
     if origin is None:
         return annotation

--- a/sqlmodel/_compat.py
+++ b/sqlmodel/_compat.py
@@ -177,6 +177,7 @@ def unwrap_newtype(tp: Any) -> Any:
         tp = tp.__supertype__
     return tp
 
+
 def get_sa_type_from_type_annotation(annotation: Any) -> Any:
     # Resolve Optional fields
     if annotation is None:

--- a/tests/test_field_newtype.py
+++ b/tests/test_field_newtype.py
@@ -1,0 +1,37 @@
+from typing import Annotated, NewType
+from uuid import UUID, uuid4
+
+from sqlmodel import Field, SQLModel
+
+
+def test_field_is_newtype() -> None:
+    NewId = NewType("NewId", UUID)
+
+    class Item(SQLModel, table=True):
+        id: NewId = Field(default_factory=uuid4, primary_key=True)
+
+    item = Item()
+    assert isinstance(item.id, UUID)
+
+
+def test_field_is_recursive_newtype() -> None:
+    NewId1 = NewType("NewId1", int)
+    NewId2 = NewType("NewId2", NewId1)
+    NewId3 = NewType("NewId3", NewId2)
+
+    class Item(SQLModel, table=True):
+        id: NewId3 = Field(primary_key=True)
+
+    item = Item(id=NewId3(NewId2(NewId1(3))))
+    assert isinstance(item.id, int)
+    assert item.id == 3, item.id
+
+
+def test_field_is_newtype_and_annotated() -> None:
+    NewId = NewType("NewId", UUID)
+
+    class Item(SQLModel, table=True):
+        id: Annotated[NewId, Field(primary_key=True)] = NewId(uuid4())
+
+    item = Item()
+    assert isinstance(item.id, UUID)


### PR DESCRIPTION
This hopefully fixes #981

I added some rudimentary tests to test my code.
If you have more things that could be tested, feel free to reach out.

Resulting SQL looks good for me:

```sql
CREATE TABLE moviefile (
        movie_id CHAR(32) NOT NULL,
)
```