### PR TITLE
Relax sqlalchemy version pin and add pre-release test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,6 +84,38 @@ jobs:
           path: coverage
           include-hidden-files: true
 
+  test-sqlalchemy-prerelease:
+    # Run tests against the latest SQLAlchemy pre-release to catch compatibility
+    # issues early. This job is intentionally not required by alls-green.
+    runs-on: ubuntu-latest
+    env:
+      UV_PYTHON: "3.14"
+      UV_RESOLUTION: highest
+      UV_PRERELEASE: allow
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.14"
+      - name: Setup uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+      - name: Install Dependencies
+        run: uv sync --no-dev --group tests --upgrade-package sqlalchemy
+      - name: Show SQLAlchemy version
+        run: uv run python -c "import sqlalchemy; print(f'SQLAlchemy {sqlalchemy.__version__}')"
+      - run: mkdir coverage
+      - name: Test
+        run: uv run bash scripts/test.sh
+        env:
+          COVERAGE_FILE: coverage/.coverage.sqlalchemy-prerelease
+          CONTEXT: sqlalchemy-prerelease
+
   coverage-combine:
     needs:
       - test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "SQLAlchemy >=2.0.14,<2.1.0",
+    "SQLAlchemy >=2.0.14,<2.2.0",
     "pydantic>=2.11.0",
     "typing-extensions>=4.5.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1842,7 +1842,7 @@ tests = [
 [package.metadata]
 requires-dist = [
     { name = "pydantic", specifier = ">=2.11.0" },
-    { name = "sqlalchemy", specifier = ">=2.0.14,<2.1.0" },
+    { name = "sqlalchemy", specifier = ">=2.0.14,<2.2.0" },
     { name = "typing-extensions", specifier = ">=4.5.0" },
 ]
 


### PR DESCRIPTION
At my company, we are driving towards compatibility with python `3.14t` free-threaded. While investigating the remaining changes necessary, we noticed that:

- Our CIs are happy with `sqlalchemy` version 2.1.0b2 + `sqlmodel` 0.0.38 (everything pass, we test mainly DB operations with `postgres` using `psycopg[c]` against local dockerized DB and against actual AWS DB).
- The test environment was tricky to build because `sqlmodel` 0.0.38 (and other versions) have a very conservative `"SQLAlchemy >=2.0.14,<2.1.0"` constraint, preventing the installation of `2.1.0b2` by default.
- As far as I could tell, `sqlmodel` seems compatible with `SQLAlchemy` 2.1.0+

This PR thus proposes 2 changes:

1. Relax the constraint to `<2.2.0`, offering support for the new `SQLAlchemy` version soon-to-be-released and by extension to free-threaded python.
2. Add a test job which runs against the latest release of `sqlalchemy`, including pre-release versions.