### PR TITLE
Relax sqlalchemy version pin and add pre-release test workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,34 +2,43 @@ name: Publish
 
 on:
   release:
-    types:
-      - created
-  workflow_dispatch:
-    inputs:
-      debug_enabled:
-        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
-        required: false
-        default: 'false'
+    types: [published]
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'Dandelion-Science/sqlmodel' }}
     permissions:
       id-token: write
-      contents: read
+      contents: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version-file: ".python-version"
-      - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-      - name: Build distribution
-        run: uv build
-      - name: Publish
-        run: uv publish
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - run: uv build
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/*.whl
+            dist/*.tar.gz
+          tag_name: ${{ github.event.release.tag_name }}
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: ${{ vars.AWS_REGION }}
+          role-to-assume: ${{ vars.ARN_IAM_ROLE_GHA_CORE }}
+      - name: Get CodeArtifact authorization token
+        run: |
+          AWS_CODEARTIFACT_TOKEN=$(aws codeartifact get-authorization-token \
+            --domain ${{ vars.CODEARTIFACT_DOMAIN }} \
+            --domain-owner ${{ vars.CODEARTIFACT_DOMAIN_OWNER }} \
+            --query authorizationToken \
+            --output text)
+          echo "AWS_CODEARTIFACT_TOKEN=$AWS_CODEARTIFACT_TOKEN" >> $GITHUB_ENV
+      - run: uv publish
+        env:
+          UV_PUBLISH_USERNAME: aws
+          UV_PUBLISH_PASSWORD: ${{ env.AWS_CODEARTIFACT_TOKEN }}
+          UV_PUBLISH_URL: ${{ vars.CODEARTIFACT_PYPI_STORE_REPOSITORY_URL }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,6 +84,38 @@ jobs:
           path: coverage
           include-hidden-files: true
 
+  test-sqlalchemy-prerelease:
+    # Run tests against the latest SQLAlchemy pre-release to catch compatibility
+    # issues early. This job is intentionally not required by alls-green.
+    runs-on: ubuntu-latest
+    env:
+      UV_PYTHON: "3.14"
+      UV_RESOLUTION: highest
+      UV_PRERELEASE: allow
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.14"
+      - name: Setup uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+      - name: Install Dependencies
+        run: uv sync --no-dev --group tests --upgrade-package sqlalchemy
+      - name: Show SQLAlchemy version
+        run: uv run python -c "import sqlalchemy; print(f'SQLAlchemy {sqlalchemy.__version__}')"
+      - run: mkdir coverage
+      - name: Test
+        run: uv run bash scripts/test.sh
+        env:
+          COVERAGE_FILE: coverage/.coverage.sqlalchemy-prerelease
+          CONTEXT: sqlalchemy-prerelease
+
   coverage-combine:
     needs:
       - test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "SQLAlchemy >=2.0.14,<2.1.0",
+    "SQLAlchemy >=2.0.14,<2.2.0",
     "pydantic>=2.11.0",
     "typing-extensions>=4.5.0",
 ]

--- a/sqlmodel/__init__.py
+++ b/sqlmodel/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.38"
+__version__ = "0.0.38.post1"
 
 # Re-export from SQLAlchemy
 from sqlalchemy.engine import create_engine as create_engine

--- a/uv.lock
+++ b/uv.lock
@@ -1842,7 +1842,7 @@ tests = [
 [package.metadata]
 requires-dist = [
     { name = "pydantic", specifier = ">=2.11.0" },
-    { name = "sqlalchemy", specifier = ">=2.0.14,<2.1.0" },
+    { name = "sqlalchemy", specifier = ">=2.0.14,<2.2.0" },
     { name = "typing-extensions", specifier = ">=4.5.0" },
 ]
 


### PR DESCRIPTION
Changes from https://github.com/fastapi/sqlmodel/pull/1884 + publication to our internal AWS CodeArtifact.