### PR TITLE
🐛 Make `FieldInfoMetadata` hashable to fix `Annotated` type usage in sets

### DIFF
--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -199,8 +199,7 @@ class RelationshipInfo(Representation):
         self.sa_relationship_args = sa_relationship_args
         self.sa_relationship_kwargs = sa_relationship_kwargs
 
-
-@dataclass
+@dataclass(unsafe_hash=True)
 class FieldInfoMetadata:
     primary_key: bool | UndefinedType = Undefined
     nullable: bool | UndefinedType = Undefined

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -199,6 +199,7 @@ class RelationshipInfo(Representation):
         self.sa_relationship_args = sa_relationship_args
         self.sa_relationship_kwargs = sa_relationship_kwargs
 
+
 @dataclass(unsafe_hash=True)
 class FieldInfoMetadata:
     primary_key: bool | UndefinedType = Undefined

--- a/tests/test_field_info_metadata_hashable.py
+++ b/tests/test_field_info_metadata_hashable.py
@@ -1,0 +1,29 @@
+from typing import Annotated
+
+from sqlmodel import Field
+from sqlmodel.main import FieldInfoMetadata
+
+
+def test_field_info_metadata_is_hashable():
+    """FieldInfoMetadata must be hashable so that Annotated types containing it
+    can be used in sets (e.g. FastAPI's OpenAPI schema generation)."""
+    meta = FieldInfoMetadata(primary_key=True)
+    hash(meta)
+
+
+def test_annotated_with_field_info_metadata_in_set():
+    """Annotated types carrying FieldInfoMetadata must work inside a set,
+    which is required by FastAPI's get_definitions()."""
+    t = Annotated[int, FieldInfoMetadata(unique=True)]
+    s = {t}
+    assert t in s
+
+
+def test_annotated_field_type_in_set():
+    """Realistic scenario: custom Annotated field aliases used in a set."""
+    PositiveInt = Annotated[int, Field(ge=0)]
+    ShortStr = Annotated[str, Field(max_length=32)]
+
+    s = {PositiveInt, ShortStr}
+    assert PositiveInt in s
+    assert ShortStr in s


### PR DESCRIPTION
### Description

`FieldInfoMetadata` is a plain `@dataclass` with implicit `__eq__`, which causes Python to set `__hash__` to `None`. When `FieldInfoMetadata` instances are used as metadata inside `typing.Annotated` types, `Annotated.__hash__` fails because it calls `hash((origin, metadata_tuple))` and the `FieldInfoMetadata` element is unhashable.

This breaks FastAPI's OpenAPI schema generation in `get_definitions()`, which collects field annotations into a `set`:

```python
input_types = {f.field_info.annotation for f in fields}
# TypeError: cannot use 'typing._AnnotatedAlias' as a set element (unhashable type: 'FieldInfoMetadata')
```

### Fix

Add `unsafe_hash=True` to the `@dataclass` decorator. This is safe because `FieldInfoMetadata` instances are effectively immutable after construction — they are created once during model class definition and never mutated afterward.

### Reproduction

Any project using custom `Annotated` field types with `FieldInfoMetadata` in the metadata (e.g. via `sqlmodel_ext` or similar libraries) will fail to generate `/openapi.json` with:

```
TypeError: cannot use 'typing._AnnotatedAlias' as a set element (unhashable type: 'FieldInfoMetadata')
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)