### PR TITLE
Remove obsolete TODO comments in test files 

### DIFF
--- a/tests/test_tutorial/test_one/test_tutorial004.py
+++ b/tests/test_tutorial/test_one/test_tutorial004.py
@@ -25,8 +25,6 @@ def test_tutorial(print_mock: PrintMock, mod: ModuleType):
     with pytest.raises(MultipleResultsFound):
         mod.main()
     with Session(mod.engine) as session:
-        # TODO: create delete() function
-        # TODO: add overloads for .exec() with delete object
         session.exec(delete(mod.Hero))
         session.add(mod.Hero(name="Test Hero", secret_name="Secret Test Hero", age=24))
         session.commit()

--- a/tests/test_tutorial/test_one/test_tutorial005.py
+++ b/tests/test_tutorial/test_one/test_tutorial005.py
@@ -25,8 +25,6 @@ def test_tutorial(print_mock: PrintMock, mod: ModuleType):
     with pytest.raises(NoResultFound):
         mod.main()
     with Session(mod.engine) as session:
-        # TODO: create delete() function
-        # TODO: add overloads for .exec() with delete object
         session.exec(delete(mod.Hero))
         session.add(mod.Hero(name="Test Hero", secret_name="Secret Test Hero", age=24))
         session.commit()


### PR DESCRIPTION
What: 
Removed two TODO comments from tests/test_tutorial/test_one/test_tutorial004.py and tests/test_tutorial/test_one/test_tutorial005.py 

Why: 
The TODOs asked for a delete() function and exec() overloads for delete objects ,both were already resolved in #1342 (which added UpdateBase overloads to Session.exec())

Scope: 
Comment removal only, no logic changes, tests pass