### PR TITLE
Add support for polymorphism models

### DIFF
--- a/sqlmodel/_compat.py
+++ b/sqlmodel/_compat.py
@@ -8,6 +8,7 @@ from typing import (
     TYPE_CHECKING,
     Annotated,
     Any,
+    ClassVar,
     ForwardRef,
     TypeAlias,
     TypeVar,
@@ -24,6 +25,8 @@ from pydantic._internal._fields import PydanticMetadata
 from pydantic._internal._model_construction import ModelMetaclass as ModelMetaclass
 from pydantic._internal._repr import Representation as Representation
 from pydantic.fields import FieldInfo
+from sqlalchemy import inspect
+from sqlalchemy.orm import InstrumentedAttribute, Mapper
 from pydantic_core import PydanticUndefined as Undefined
 from pydantic_core import PydanticUndefinedType as PydanticUndefinedType
 
@@ -66,6 +69,93 @@ def _is_union_type(t: Any) -> bool:
 
 
 finish_init: ContextVar[bool] = ContextVar("finish_init", default=True)
+
+
+def set_polymorphic_default_value(
+    self_instance: _TSQLModel,
+    values: dict[str, Any],
+) -> bool:
+    """By default, when init a model, pydantic will set the polymorphic_on
+    value to field default value. But when inherit a model, the polymorphic_on
+    should be set to polymorphic_identity value by default."""
+    cls = type(self_instance)
+    mapper = inspect(cls)
+    ret = False
+    if isinstance(mapper, Mapper):
+        polymorphic_on = mapper.polymorphic_on
+        if polymorphic_on is not None:
+            polymorphic_property = mapper.get_property_by_column(polymorphic_on)
+            field_info = get_model_fields(cls).get(polymorphic_property.key)
+            if field_info:
+                v = values.get(polymorphic_property.key)
+                if mapper.inherits or v is None:
+                    setattr(
+                        self_instance,
+                        polymorphic_property.key,
+                        mapper.polymorphic_identity,
+                    )
+                    ret = True
+    return ret
+
+
+def _wrap_inherited_relationships_as_classvar(
+    base: type,
+    base_annotations: dict[str, Any],
+    dict_used: dict[str, Any],
+) -> None:
+    """Convert inherited relationship annotations to ClassVar on the subclass.
+
+    Pydantic would try to treat inherited SQLAlchemy relationship descriptors as plain
+    fields, which fails at class-creation time.  Tagging them ClassVar tells
+    Pydantic to ignore them while SQLAlchemy continues to own the attribute.
+    """
+    if not hasattr(base, "__sqlmodel_relationships__"):
+        return
+    for k in base.__sqlmodel_relationships__:
+        anno = base_annotations.get(k, Any)
+        if get_origin(anno) is not ClassVar:
+            dict_used["__annotations__"][k] = ClassVar[anno]  # type: ignore[valid-type]
+
+
+def _is_polymorphic_subclass(bases: tuple[type, ...]) -> bool:
+    """Return True when any base class already defines a ``__tablename__``.
+
+    This distinguishes a polymorphic subclass (which inherits from an existing
+    table model) from a root table model that defines its own table.
+    """
+    return any(
+        issubclass(base, BaseModel) and hasattr(base, "__tablename__")
+        for base in bases
+    )
+
+
+def _collect_inherited_namespace(
+    bases: tuple[type, ...],
+    dict_used: dict[str, Any],
+) -> dict[str, Any]:
+    """Merge base-class fields/annotations into *dict_used* for polymorphic subclasses.
+
+    Walks bases in method resolution order (reversed so the most-specific base wins),
+    collecting Pydantic field definitions and annotations from every
+    SQLModel table parent, and marking inherited relationships as ClassVar
+    so Pydantic ignores them.
+    """
+    base_fields: dict[str, Any] = {}
+    base_annotations: dict[str, Any] = {}
+    for base in bases[::-1]:
+        if not issubclass(base, BaseModel):
+            continue
+        base_model_fields = get_model_fields(base)
+        base_fields.update(base_model_fields)
+        for k in base_model_fields:
+            if k in base.__annotations__:
+                base_annotations[k] = base.__annotations__[k]
+        _wrap_inherited_relationships_as_classvar(base, base_annotations, dict_used)
+    base_annotations.update(dict_used["__annotations__"])
+    dict_used["__annotations__"] = base_annotations
+    base_fields.update(dict_used)
+    return base_fields
+
 
 
 @contextmanager
@@ -270,6 +360,8 @@ def sqlmodel_table_construct(
         if value is not Undefined:
             setattr(self_instance, key, value)
     # End SQLModel override
+    # Override polymorphic_on default value
+    set_polymorphic_default_value(self_instance, values)
     return self_instance
 
 

--- a/sqlmodel/_compat.py
+++ b/sqlmodel/_compat.py
@@ -25,10 +25,10 @@ from pydantic._internal._fields import PydanticMetadata
 from pydantic._internal._model_construction import ModelMetaclass as ModelMetaclass
 from pydantic._internal._repr import Representation as Representation
 from pydantic.fields import FieldInfo
-from sqlalchemy import inspect
-from sqlalchemy.orm import InstrumentedAttribute, Mapper
 from pydantic_core import PydanticUndefined as Undefined
 from pydantic_core import PydanticUndefinedType as PydanticUndefinedType
+from sqlalchemy import inspect
+from sqlalchemy.orm import Mapper
 
 BaseConfig = ConfigDict
 UndefinedType = PydanticUndefinedType
@@ -124,8 +124,7 @@ def _is_polymorphic_subclass(bases: tuple[type, ...]) -> bool:
     table model) from a root table model that defines its own table.
     """
     return any(
-        issubclass(base, BaseModel) and hasattr(base, "__tablename__")
-        for base in bases
+        issubclass(base, BaseModel) and hasattr(base, "__tablename__") for base in bases
     )
 
 
@@ -159,7 +158,11 @@ def _collect_inherited_namespace(
 
 def _relationship_keys(instance: _TSQLModel) -> Iterable[str]:
     mapper = inspect(type(instance), raiseerr=False)
-    return mapper.relationships.keys() if mapper is not None else instance.__sqlmodel_relationships__
+    return (
+        mapper.relationships.keys()
+        if mapper is not None
+        else instance.__sqlmodel_relationships__
+    )
 
 
 @contextmanager

--- a/sqlmodel/_compat.py
+++ b/sqlmodel/_compat.py
@@ -1,6 +1,6 @@
 import sys
 import types
-from collections.abc import Generator
+from collections.abc import Generator, Iterable
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -156,6 +156,10 @@ def _collect_inherited_namespace(
     base_fields.update(dict_used)
     return base_fields
 
+
+def _relationship_keys(instance: _TSQLModel) -> Iterable[str]:
+    mapper = inspect(type(instance), raiseerr=False)
+    return mapper.relationships.keys() if mapper is not None else instance.__sqlmodel_relationships__
 
 
 @contextmanager
@@ -355,7 +359,7 @@ def sqlmodel_table_construct(
         object.__setattr__(self_instance, "__pydantic_private__", None)
     # SQLModel override, set relationships
     # Get and set any relationship objects
-    for key in self_instance.__sqlmodel_relationships__:
+    for key in _relationship_keys(self_instance):
         value = values.get(key, Undefined)
         if value is not Undefined:
             setattr(self_instance, key, value)
@@ -411,7 +415,7 @@ def sqlmodel_validate(
     object.__setattr__(new_obj, "__pydantic_fields_set__", fields_set)
     # Get and set any relationship objects
     if is_table_model_class(cls):
-        for key in new_obj.__sqlmodel_relationships__:
+        for key in _relationship_keys(new_obj):
             value = getattr(use_obj, key, Undefined)
             if value is not Undefined:
                 setattr(new_obj, key, value)

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -870,6 +870,14 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
         if finish_init.get():
             sqlmodel_init(self=__pydantic_self__, data=data)
 
+    def _is_sqlmodel_relationship(self, name: str) -> bool:
+        if name in self.__sqlmodel_relationships__:
+            return True
+        if not (is_table_model_class(self.__class__) and is_instrumented(self, name)):
+            return False
+        mapper = inspect(self.__class__, raiseerr=False)
+        return mapper is not None and name in mapper.relationships
+
     def __setattr__(self, name: str, value: Any) -> None:
         if name in {"_sa_instance_state"}:
             self.__dict__[name] = value
@@ -880,7 +888,7 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
                 set_attribute(self, name, value)
             # Set in Pydantic model to trigger possible validation changes, only for
             # non relationship values
-            if name not in self.__sqlmodel_relationships__:
+            if not self._is_sqlmodel_relationship(name):
                 super().__setattr__(name, value)
 
     def __repr_args__(self) -> Sequence[tuple[str | None, Any]]:

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -595,7 +595,8 @@ class SQLModelMetaclass(ModelMetaclass, DeclarativeMeta):
                 )
         else:
             new_cls = cast(
-                "SQLModel", super().__new__(cls, name, bases, dict_used, **config_kwargs)
+                "SQLModel",
+                super().__new__(cls, name, bases, dict_used, **config_kwargs),
             )
         new_cls.__annotations__ = {
             **relationship_annotations,
@@ -765,7 +766,7 @@ def get_sqlalchemy_type(field: Any) -> Any:
     raise ValueError(f"{type_} has no matching SQLAlchemy type")
 
 
-def get_column_from_field(field: Any) -> Union[Column, MappedColumn]:  # type: ignore
+def get_column_from_field(field: Any) -> Column | MappedColumn:  # type: ignore
     field_info = field
     sa_column = _get_sqlmodel_field_value(field_info, "sa_column", Undefined)
     if isinstance(sa_column, Column) or isinstance(sa_column, MappedColumn):

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import builtins
 import ipaddress
 import uuid
+import warnings
 from collections.abc import Callable, Mapping, Sequence, Set
 from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta
@@ -38,9 +39,10 @@ from sqlalchemy import (
 )
 from sqlalchemy import Enum as sa_Enum
 from sqlalchemy.orm import (
+    InstrumentedAttribute,
     Mapped,
+    MappedColumn,
     RelationshipProperty,
-    declared_attr,
     registry,
     relationship,
 )
@@ -59,6 +61,8 @@ from ._compat import (
     SQLModelConfig,
     Undefined,
     UndefinedType,
+    _collect_inherited_namespace,
+    _is_polymorphic_subclass,
     finish_init,
     get_annotations,
     get_field_metadata,
@@ -578,9 +582,21 @@ class SQLModelMetaclass(ModelMetaclass, DeclarativeMeta):
         config_kwargs = {
             key: kwargs[key] for key in kwargs.keys() & allowed_config_kwargs
         }
-        new_cls = cast(
-            "SQLModel", super().__new__(cls, name, bases, dict_used, **config_kwargs)
-        )
+        dict_used = _collect_inherited_namespace(bases, dict_used)
+        if _is_polymorphic_subclass(bases):
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    message="Field name .+ shadows an attribute in parent.+",
+                )
+                new_cls = cast(
+                    "SQLModel",
+                    super().__new__(cls, name, bases, dict_used, **config_kwargs),
+                )
+        else:
+            new_cls = cast(
+                "SQLModel", super().__new__(cls, name, bases, dict_used, **config_kwargs)
+            )
         new_cls.__annotations__ = {
             **relationship_annotations,
             **pydantic_annotations,
@@ -598,9 +614,16 @@ class SQLModelMetaclass(ModelMetaclass, DeclarativeMeta):
 
         config_table = get_config("table")
         if config_table is True:
+            if new_cls.__name__ != "SQLModel" and not hasattr(new_cls, "__tablename__"):
+                setattr(new_cls, "__tablename__", new_cls.__name__.lower())  # noqa: B010
             # If it was passed by kwargs, ensure it's also set in config
             new_cls.model_config["table"] = config_table
             for k, v in get_model_fields(new_cls).items():
+                if (
+                    isinstance(getattr(new_cls, k, None), InstrumentedAttribute)
+                    and k not in class_dict
+                ):
+                    continue
                 col = get_column_from_field(v)
                 setattr(new_cls, k, col)
             # Set a config flag to tell FastAPI that this should be read with a field
@@ -632,7 +655,12 @@ class SQLModelMetaclass(ModelMetaclass, DeclarativeMeta):
         # trying to create a new SQLAlchemy, for a new table, with the same name, that
         # triggers an error
         base_is_table = any(is_table_model_class(base) for base in bases)
-        if is_table_model_class(cls) and not base_is_table:
+        _mapper_args = dict_.get("__mapper_args__", {})
+        has_polymorphic = (
+            _mapper_args.get("polymorphic_identity") is not None
+            or _mapper_args.get("polymorphic_abstract") is not None
+        )
+        if is_table_model_class(cls) and (not base_is_table or has_polymorphic):
             for rel_name, rel_info in cls.__sqlmodel_relationships__.items():
                 if rel_info.sa_relationship:
                     # There's a SQLAlchemy relationship declared, that takes precedence
@@ -737,10 +765,10 @@ def get_sqlalchemy_type(field: Any) -> Any:
     raise ValueError(f"{type_} has no matching SQLAlchemy type")
 
 
-def get_column_from_field(field: Any) -> Column:
+def get_column_from_field(field: Any) -> Union[Column, MappedColumn]:  # type: ignore
     field_info = field
     sa_column = _get_sqlmodel_field_value(field_info, "sa_column", Undefined)
-    if isinstance(sa_column, Column):
+    if isinstance(sa_column, Column) or isinstance(sa_column, MappedColumn):
         return sa_column
     sa_type = get_sqlalchemy_type(field)
     primary_key = _get_sqlmodel_field_value(field_info, "primary_key", Undefined)
@@ -804,7 +832,6 @@ _TSQLModel = TypeVar("_TSQLModel", bound="SQLModel")
 class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry):
     # SQLAlchemy needs to set weakref(s), Pydantic will set the other slots values
     __slots__ = ("__weakref__",)
-    __tablename__: ClassVar[str | Callable[..., str]]
     __sqlmodel_relationships__: ClassVar[builtins.dict[str, RelationshipProperty[Any]]]
     __name__: ClassVar[str]
     metadata: ClassVar[MetaData]
@@ -863,10 +890,6 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
             for k, v in super().__repr_args__()
             if not (isinstance(k, str) and k.startswith("_sa_"))
         ]
-
-    @declared_attr  # type: ignore
-    def __tablename__(cls) -> str:
-        return cls.__name__.lower()
 
     @classmethod
     def model_validate(  # ty: ignore[invalid-method-override]

--- a/tests/test_polymorphic/test_basic.py
+++ b/tests/test_polymorphic/test_basic.py
@@ -1,0 +1,118 @@
+"""Mirrors sqlalchemy/test/orm/inheritance/test_basic.py :: FalseDiscriminatorTest, CascadeTest"""
+
+from typing import Optional
+
+from sqlalchemy import Boolean
+from sqlalchemy.orm import mapped_column
+from sqlmodel import Field, Relationship, Session, SQLModel, create_engine, select
+
+
+def test_false_discriminator_on_sub():
+    # mirrors FalseDiscriminatorTest.test_false_on_sub
+    class DFoo(SQLModel, table=True):
+        __tablename__ = "t_false_sub"
+        id: Optional[int] = Field(default=None, primary_key=True)
+        type: Optional[bool] = Field(
+            default=None, sa_column=mapped_column(Boolean, nullable=True)
+        )
+
+        __mapper_args__ = {"polymorphic_on": "type", "polymorphic_identity": True}
+
+    class DBar(DFoo):
+        __mapper_args__ = {"polymorphic_identity": False}
+
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as db:
+        b1 = DBar()
+        db.add(b1)
+        db.commit()
+        db.refresh(b1)
+        assert b1.type is False
+
+    with Session(engine) as db:
+        result = db.exec(select(DFoo)).one()
+        assert isinstance(result, DBar)
+
+
+def test_false_discriminator_on_base():
+    # mirrors FalseDiscriminatorTest.test_false_on_base
+    class Ding(SQLModel, table=True):
+        __tablename__ = "t_false_base"
+        id: Optional[int] = Field(default=None, primary_key=True)
+        type: Optional[bool] = Field(
+            default=None, sa_column=mapped_column(Boolean, nullable=True)
+        )
+
+        __mapper_args__ = {"polymorphic_on": "type", "polymorphic_identity": False}
+
+    class Bat(Ding):
+        __mapper_args__ = {"polymorphic_identity": True}
+
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as db:
+        d1 = Ding()
+        db.add(d1)
+        db.commit()
+        db.refresh(d1)
+        assert d1.type is False
+
+    with Session(engine) as db:
+        assert db.exec(select(Ding)).one() is not None
+
+
+def test_cascade_delete_follows_subclass_mapper():
+    # mirrors CascadeTest.test_cascade
+    class Note(SQLModel, table=True):
+        __tablename__ = "cascade_note"
+        id: Optional[int] = Field(default=None, primary_key=True)
+        data: str
+        item_id: Optional[int] = Field(default=None, foreign_key="cascade_item.id")
+
+    class Item(SQLModel, table=True):
+        __tablename__ = "cascade_item"
+        id: Optional[int] = Field(default=None, primary_key=True)
+        type: str = Field(default="item")
+        data: str
+        notes: list[Note] = Relationship(sa_relationship_kwargs={"cascade": "all"})
+
+        __mapper_args__ = {
+            "polymorphic_on": "type",
+            "polymorphic_identity": "item",
+        }
+
+    class SubItem(Item):
+        __tablename__ = "cascade_subitem"
+        id: Optional[int] = Field(
+            default=None, primary_key=True, foreign_key="cascade_item.id"
+        )
+        extra: str = Field(default="")
+
+        __mapper_args__ = {"polymorphic_identity": "subitem"}
+
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as db:
+        sub = SubItem(data="hello", extra="world")
+        db.add(sub)
+        db.flush()
+        sub_id = sub.id
+        db.add(Note(data="note1", item_id=sub_id))
+        db.add(Note(data="note2", item_id=sub_id))
+        db.commit()
+
+    with Session(engine) as db:
+        sub = db.get(SubItem, sub_id)
+        _ = sub.notes
+        db.delete(sub)
+        db.commit()
+
+    with Session(engine) as db:
+        assert db.exec(select(Note)).all() == []
+        assert db.exec(select(Item)).all() == []
+
+

--- a/tests/test_polymorphic/test_basic.py
+++ b/tests/test_polymorphic/test_basic.py
@@ -1,7 +1,5 @@
 """Mirrors sqlalchemy/test/orm/inheritance/test_basic.py :: FalseDiscriminatorTest, CascadeTest"""
 
-from typing import Optional
-
 from sqlalchemy import Boolean
 from sqlalchemy.orm import mapped_column
 from sqlmodel import Field, Relationship, Session, SQLModel, create_engine, select
@@ -11,8 +9,8 @@ def test_false_discriminator_on_sub():
     # mirrors FalseDiscriminatorTest.test_false_on_sub
     class DFoo(SQLModel, table=True):
         __tablename__ = "t_false_sub"
-        id: Optional[int] = Field(default=None, primary_key=True)
-        type: Optional[bool] = Field(
+        id: int | None = Field(default=None, primary_key=True)
+        type: bool | None = Field(
             default=None, sa_column=mapped_column(Boolean, nullable=True)
         )
 
@@ -40,8 +38,8 @@ def test_false_discriminator_on_base():
     # mirrors FalseDiscriminatorTest.test_false_on_base
     class Ding(SQLModel, table=True):
         __tablename__ = "t_false_base"
-        id: Optional[int] = Field(default=None, primary_key=True)
-        type: Optional[bool] = Field(
+        id: int | None = Field(default=None, primary_key=True)
+        type: bool | None = Field(
             default=None, sa_column=mapped_column(Boolean, nullable=True)
         )
 
@@ -68,13 +66,13 @@ def test_cascade_delete_follows_subclass_mapper():
     # mirrors CascadeTest.test_cascade
     class Note(SQLModel, table=True):
         __tablename__ = "cascade_note"
-        id: Optional[int] = Field(default=None, primary_key=True)
+        id: int | None = Field(default=None, primary_key=True)
         data: str
-        item_id: Optional[int] = Field(default=None, foreign_key="cascade_item.id")
+        item_id: int | None = Field(default=None, foreign_key="cascade_item.id")
 
     class Item(SQLModel, table=True):
         __tablename__ = "cascade_item"
-        id: Optional[int] = Field(default=None, primary_key=True)
+        id: int | None = Field(default=None, primary_key=True)
         type: str = Field(default="item")
         data: str
         notes: list[Note] = Relationship(sa_relationship_kwargs={"cascade": "all"})
@@ -86,7 +84,7 @@ def test_cascade_delete_follows_subclass_mapper():
 
     class SubItem(Item):
         __tablename__ = "cascade_subitem"
-        id: Optional[int] = Field(
+        id: int | None = Field(
             default=None, primary_key=True, foreign_key="cascade_item.id"
         )
         extra: str = Field(default="")
@@ -114,5 +112,3 @@ def test_cascade_delete_follows_subclass_mapper():
     with Session(engine) as db:
         assert db.exec(select(Note)).all() == []
         assert db.exec(select(Item)).all() == []
-
-

--- a/tests/test_polymorphic/test_concrete.py
+++ b/tests/test_polymorphic/test_concrete.py
@@ -1,0 +1,124 @@
+"""Mirrors sqlalchemy/test/orm/inheritance/test_concrete.py :: ConcreteTest, PropertyInheritanceTest"""
+
+from typing import Optional
+
+from sqlmodel import Field, Relationship, Session, SQLModel, create_engine, select
+
+
+def test_basic():
+    # mirrors ConcreteTest.test_basic
+    class Manager(SQLModel, table=True):
+        __tablename__ = "cti_managers"
+        employee_id: Optional[int] = Field(default=None, primary_key=True)
+        name: str
+        manager_data: str
+
+    class Engineer(SQLModel, table=True):
+        __tablename__ = "cti_engineers"
+        employee_id: Optional[int] = Field(default=None, primary_key=True)
+        name: str
+        engineer_info: str
+
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as db:
+        db.add(Manager(name="Sally", manager_data="knows how to manage things"))
+        db.add(Engineer(name="Karina", engineer_info="knows how to hack"))
+        db.commit()
+
+    with Session(engine) as db:
+        managers = db.exec(select(Manager)).all()
+        engineers = db.exec(select(Engineer)).all()
+
+        db.expire(managers[0], ["manager_data"])
+        assert managers[0].manager_data == "knows how to manage things"
+
+    assert {m.name for m in managers} == {"Sally"}
+    assert {e.name for e in engineers} == {"Karina"}
+
+
+def test_multi_level_no_base():
+    # mirrors ConcreteTest.test_multi_level_no_base
+    class Manager(SQLModel, table=True):
+        __tablename__ = "cti3_managers"
+        employee_id: Optional[int] = Field(default=None, primary_key=True)
+        name: str
+        manager_data: str
+
+    class Engineer(SQLModel, table=True):
+        __tablename__ = "cti3_engineers"
+        employee_id: Optional[int] = Field(default=None, primary_key=True)
+        name: str
+        engineer_info: str
+
+    class Hacker(SQLModel, table=True):
+        __tablename__ = "cti3_hackers"
+        employee_id: Optional[int] = Field(default=None, primary_key=True)
+        name: str
+        engineer_info: str
+        nickname: str
+
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as db:
+        db.add(Manager(name="Sally", manager_data="knows how to manage things"))
+        db.add(Engineer(name="Jenn", engineer_info="knows how to program"))
+        db.add(Hacker(name="Karina", engineer_info="knows how to hack", nickname="Badass"))
+        db.commit()
+
+    with Session(engine) as db:
+        managers = db.exec(select(Manager)).all()
+        engineers = db.exec(select(Engineer)).all()
+        hackers = db.exec(select(Hacker)).all()
+
+    assert len(managers) == 1 and managers[0].name == "Sally"
+    assert len(engineers) == 1 and engineers[0].engineer_info == "knows how to program"
+    assert len(hackers) == 1 and hackers[0].nickname == "Badass"
+
+    with Session(engine) as db:
+        assert db.exec(select(Manager).where(Manager.name == "Karina")).first() is None
+
+
+def test_relationship():
+    # mirrors ConcreteTest.test_relationship / PropertyInheritanceTest
+    class Company(SQLModel, table=True):
+        __tablename__ = "cti4_companies"
+        id: Optional[int] = Field(default=None, primary_key=True)
+        name: str
+        managers: list["CtiManager"] = Relationship(back_populates="company")
+        engineers: list["CtiEngineer"] = Relationship(back_populates="company")
+
+    class CtiManager(SQLModel, table=True):
+        __tablename__ = "cti4_managers"
+        employee_id: Optional[int] = Field(default=None, primary_key=True)
+        name: str
+        manager_data: str
+        company_id: Optional[int] = Field(default=None, foreign_key="cti4_companies.id")
+        company: Optional[Company] = Relationship(back_populates="managers")
+
+    class CtiEngineer(SQLModel, table=True):
+        __tablename__ = "cti4_engineers"
+        employee_id: Optional[int] = Field(default=None, primary_key=True)
+        name: str
+        engineer_info: str
+        company_id: Optional[int] = Field(default=None, foreign_key="cti4_companies.id")
+        company: Optional[Company] = Relationship(back_populates="engineers")
+
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as db:
+        corp = Company(name="Initech")
+        db.add(corp)
+        db.flush()
+        cid = corp.id
+        db.add(CtiManager(name="Bill", manager_data="TPS reports", company_id=cid))
+        db.add(CtiEngineer(name="Peter", engineer_info="cubicle dweller", company_id=cid))
+        db.commit()
+
+    with Session(engine) as db:
+        corp = db.get(Company, cid)
+        assert len(corp.managers) == 1 and corp.managers[0].name == "Bill"
+        assert len(corp.engineers) == 1 and corp.engineers[0].name == "Peter"

--- a/tests/test_polymorphic/test_concrete.py
+++ b/tests/test_polymorphic/test_concrete.py
@@ -1,7 +1,5 @@
 """Mirrors sqlalchemy/test/orm/inheritance/test_concrete.py :: ConcreteTest, PropertyInheritanceTest"""
 
-from typing import Optional
-
 from sqlmodel import Field, Relationship, Session, SQLModel, create_engine, select
 
 
@@ -9,13 +7,13 @@ def test_basic():
     # mirrors ConcreteTest.test_basic
     class Manager(SQLModel, table=True):
         __tablename__ = "cti_managers"
-        employee_id: Optional[int] = Field(default=None, primary_key=True)
+        employee_id: int | None = Field(default=None, primary_key=True)
         name: str
         manager_data: str
 
     class Engineer(SQLModel, table=True):
         __tablename__ = "cti_engineers"
-        employee_id: Optional[int] = Field(default=None, primary_key=True)
+        employee_id: int | None = Field(default=None, primary_key=True)
         name: str
         engineer_info: str
 
@@ -42,19 +40,19 @@ def test_multi_level_no_base():
     # mirrors ConcreteTest.test_multi_level_no_base
     class Manager(SQLModel, table=True):
         __tablename__ = "cti3_managers"
-        employee_id: Optional[int] = Field(default=None, primary_key=True)
+        employee_id: int | None = Field(default=None, primary_key=True)
         name: str
         manager_data: str
 
     class Engineer(SQLModel, table=True):
         __tablename__ = "cti3_engineers"
-        employee_id: Optional[int] = Field(default=None, primary_key=True)
+        employee_id: int | None = Field(default=None, primary_key=True)
         name: str
         engineer_info: str
 
     class Hacker(SQLModel, table=True):
         __tablename__ = "cti3_hackers"
-        employee_id: Optional[int] = Field(default=None, primary_key=True)
+        employee_id: int | None = Field(default=None, primary_key=True)
         name: str
         engineer_info: str
         nickname: str
@@ -65,7 +63,9 @@ def test_multi_level_no_base():
     with Session(engine) as db:
         db.add(Manager(name="Sally", manager_data="knows how to manage things"))
         db.add(Engineer(name="Jenn", engineer_info="knows how to program"))
-        db.add(Hacker(name="Karina", engineer_info="knows how to hack", nickname="Badass"))
+        db.add(
+            Hacker(name="Karina", engineer_info="knows how to hack", nickname="Badass")
+        )
         db.commit()
 
     with Session(engine) as db:
@@ -85,26 +85,26 @@ def test_relationship():
     # mirrors ConcreteTest.test_relationship / PropertyInheritanceTest
     class Company(SQLModel, table=True):
         __tablename__ = "cti4_companies"
-        id: Optional[int] = Field(default=None, primary_key=True)
+        id: int | None = Field(default=None, primary_key=True)
         name: str
         managers: list["CtiManager"] = Relationship(back_populates="company")
         engineers: list["CtiEngineer"] = Relationship(back_populates="company")
 
     class CtiManager(SQLModel, table=True):
         __tablename__ = "cti4_managers"
-        employee_id: Optional[int] = Field(default=None, primary_key=True)
+        employee_id: int | None = Field(default=None, primary_key=True)
         name: str
         manager_data: str
-        company_id: Optional[int] = Field(default=None, foreign_key="cti4_companies.id")
-        company: Optional[Company] = Relationship(back_populates="managers")
+        company_id: int | None = Field(default=None, foreign_key="cti4_companies.id")
+        company: Company | None = Relationship(back_populates="managers")
 
     class CtiEngineer(SQLModel, table=True):
         __tablename__ = "cti4_engineers"
-        employee_id: Optional[int] = Field(default=None, primary_key=True)
+        employee_id: int | None = Field(default=None, primary_key=True)
         name: str
         engineer_info: str
-        company_id: Optional[int] = Field(default=None, foreign_key="cti4_companies.id")
-        company: Optional[Company] = Relationship(back_populates="engineers")
+        company_id: int | None = Field(default=None, foreign_key="cti4_companies.id")
+        company: Company | None = Relationship(back_populates="engineers")
 
     engine = create_engine("sqlite:///:memory:")
     SQLModel.metadata.create_all(engine)
@@ -115,7 +115,9 @@ def test_relationship():
         db.flush()
         cid = corp.id
         db.add(CtiManager(name="Bill", manager_data="TPS reports", company_id=cid))
-        db.add(CtiEngineer(name="Peter", engineer_info="cubicle dweller", company_id=cid))
+        db.add(
+            CtiEngineer(name="Peter", engineer_info="cubicle dweller", company_id=cid)
+        )
         db.commit()
 
     with Session(engine) as db:

--- a/tests/test_polymorphic/test_manytomany.py
+++ b/tests/test_polymorphic/test_manytomany.py
@@ -1,25 +1,22 @@
 """Mirrors sqlalchemy/test/orm/inheritance/test_manytomany.py"""
 
-from typing import Optional
-
 from sqlmodel import Field, Relationship, Session, SQLModel, create_engine
-
 
 
 # Two jointed table inheritance subclasses (User, Group) linked many to many; both sides of the relationship resolve correctly.
 def test_jti_m2m_subclass_to_subclass():
     class UserGroupLink(SQLModel, table=True):
         __tablename__ = "prin_user_group_map"
-        user_id: Optional[int] = Field(
+        user_id: int | None = Field(
             default=None, foreign_key="prin_users.id", primary_key=True
         )
-        group_id: Optional[int] = Field(
+        group_id: int | None = Field(
             default=None, foreign_key="prin_groups.id", primary_key=True
         )
 
     class Principal(SQLModel, table=True):
         __tablename__ = "principals"
-        id: Optional[int] = Field(default=None, primary_key=True)
+        id: int | None = Field(default=None, primary_key=True)
         name: str
         type: str = Field(default="principal")
 
@@ -30,7 +27,7 @@ def test_jti_m2m_subclass_to_subclass():
 
     class User(Principal, table=True):
         __tablename__ = "prin_users"
-        id: Optional[int] = Field(
+        id: int | None = Field(
             default=None, primary_key=True, foreign_key="principals.id"
         )
         password: str
@@ -44,7 +41,7 @@ def test_jti_m2m_subclass_to_subclass():
 
     class Group(Principal, table=True):
         __tablename__ = "prin_groups"
-        id: Optional[int] = Field(
+        id: int | None = Field(
             default=None, primary_key=True, foreign_key="principals.id"
         )
         users: list[User] = Relationship(
@@ -80,17 +77,17 @@ def test_jti_m2m_subclass_to_subclass():
 def test_jti_m2m_get_by_subclass_pk():
     class FooBarLink(SQLModel, table=True):
         __tablename__ = "foo_bar_link"
-        foo_id: Optional[int] = Field(
+        foo_id: int | None = Field(
             default=None, foreign_key="m2m_foo.id", primary_key=True
         )
-        bar_id: Optional[int] = Field(
+        bar_id: int | None = Field(
             default=None, foreign_key="m2m_bar.id", primary_key=True
         )
 
     class Foo(SQLModel, table=True):
         __tablename__ = "m2m_foo"
-        id: Optional[int] = Field(default=None, primary_key=True)
-        data: Optional[str] = None
+        id: int | None = Field(default=None, primary_key=True)
+        data: str | None = None
         type: str = Field(default="foo")
 
         __mapper_args__ = {
@@ -100,9 +97,7 @@ def test_jti_m2m_get_by_subclass_pk():
 
     class Bar(Foo, table=True):
         __tablename__ = "m2m_bar"
-        id: Optional[int] = Field(
-            default=None, primary_key=True, foreign_key="m2m_foo.id"
-        )
+        id: int | None = Field(default=None, primary_key=True, foreign_key="m2m_foo.id")
         foos: list[Foo] = Relationship(link_model=FooBarLink)
 
         __mapper_args__ = {"polymorphic_identity": "bar"}
@@ -133,26 +128,26 @@ def test_jti_m2m_get_by_subclass_pk():
 def test_jti_m2m_three_level():
     class BlubBarLink(SQLModel, table=True):
         __tablename__ = "blub_bar_link"
-        blub_id: Optional[int] = Field(
+        blub_id: int | None = Field(
             default=None, foreign_key="m3_blub.id", primary_key=True
         )
-        bar_id: Optional[int] = Field(
+        bar_id: int | None = Field(
             default=None, foreign_key="m3_bar.id", primary_key=True
         )
 
     class BlubFooLink(SQLModel, table=True):
         __tablename__ = "blub_foo_link"
-        blub_id: Optional[int] = Field(
+        blub_id: int | None = Field(
             default=None, foreign_key="m3_blub.id", primary_key=True
         )
-        foo_id: Optional[int] = Field(
+        foo_id: int | None = Field(
             default=None, foreign_key="m3_foo.id", primary_key=True
         )
 
     class Foo(SQLModel, table=True):
         __tablename__ = "m3_foo"
-        id: Optional[int] = Field(default=None, primary_key=True)
-        data: Optional[str] = None
+        id: int | None = Field(default=None, primary_key=True)
+        data: str | None = None
         type: str = Field(default="foo")
 
         __mapper_args__ = {
@@ -162,19 +157,15 @@ def test_jti_m2m_three_level():
 
     class Bar(Foo, table=True):
         __tablename__ = "m3_bar"
-        id: Optional[int] = Field(
-            default=None, primary_key=True, foreign_key="m3_foo.id"
-        )
-        bar_data: Optional[str] = None
+        id: int | None = Field(default=None, primary_key=True, foreign_key="m3_foo.id")
+        bar_data: str | None = None
 
         __mapper_args__ = {"polymorphic_identity": "bar"}
 
     class Blub(Bar, table=True):
         __tablename__ = "m3_blub"
-        id: Optional[int] = Field(
-            default=None, primary_key=True, foreign_key="m3_bar.id"
-        )
-        blub_data: Optional[str] = None
+        id: int | None = Field(default=None, primary_key=True, foreign_key="m3_bar.id")
+        blub_data: str | None = None
         bars: list[Bar] = Relationship(link_model=BlubBarLink)
         foos: list[Foo] = Relationship(link_model=BlubFooLink)
 

--- a/tests/test_polymorphic/test_manytomany.py
+++ b/tests/test_polymorphic/test_manytomany.py
@@ -1,0 +1,201 @@
+"""Mirrors sqlalchemy/test/orm/inheritance/test_manytomany.py"""
+
+from typing import Optional
+
+from sqlmodel import Field, Relationship, Session, SQLModel, create_engine
+
+
+
+# Two jointed table inheritance subclasses (User, Group) linked many to many; both sides of the relationship resolve correctly.
+def test_jti_m2m_subclass_to_subclass():
+    class UserGroupLink(SQLModel, table=True):
+        __tablename__ = "prin_user_group_map"
+        user_id: Optional[int] = Field(
+            default=None, foreign_key="prin_users.id", primary_key=True
+        )
+        group_id: Optional[int] = Field(
+            default=None, foreign_key="prin_groups.id", primary_key=True
+        )
+
+    class Principal(SQLModel, table=True):
+        __tablename__ = "principals"
+        id: Optional[int] = Field(default=None, primary_key=True)
+        name: str
+        type: str = Field(default="principal")
+
+        __mapper_args__ = {
+            "polymorphic_on": "type",
+            "polymorphic_identity": "principal",
+        }
+
+    class User(Principal, table=True):
+        __tablename__ = "prin_users"
+        id: Optional[int] = Field(
+            default=None, primary_key=True, foreign_key="principals.id"
+        )
+        password: str
+        email: str
+        login_id: str
+        groups: list["Group"] = Relationship(
+            back_populates="users", link_model=UserGroupLink
+        )
+
+        __mapper_args__ = {"polymorphic_identity": "user"}
+
+    class Group(Principal, table=True):
+        __tablename__ = "prin_groups"
+        id: Optional[int] = Field(
+            default=None, primary_key=True, foreign_key="principals.id"
+        )
+        users: list[User] = Relationship(
+            back_populates="groups", link_model=UserGroupLink
+        )
+
+        __mapper_args__ = {"polymorphic_identity": "group"}
+
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as db:
+        u = User(name="user1", password="pw", email="foo@bar.com", login_id="lg1")
+        g = Group(name="group1")
+        g.users.append(u)
+        db.add(g)
+        db.flush()
+        group_id, user_id = g.id, u.id
+        db.commit()
+
+    with Session(engine) as db:
+        g = db.get(Group, group_id)
+        assert len(g.users) == 1
+        assert g.users[0].id == user_id
+        assert g.users[0].name == "user1"
+
+        u = db.get(User, user_id)
+        assert len(u.groups) == 1
+        assert u.groups[0].id == group_id
+
+
+# db.get(Bar, id) works when Bar is a jointed table inheritance subclass with its own primary key column.
+def test_jti_m2m_get_by_subclass_pk():
+    class FooBarLink(SQLModel, table=True):
+        __tablename__ = "foo_bar_link"
+        foo_id: Optional[int] = Field(
+            default=None, foreign_key="m2m_foo.id", primary_key=True
+        )
+        bar_id: Optional[int] = Field(
+            default=None, foreign_key="m2m_bar.id", primary_key=True
+        )
+
+    class Foo(SQLModel, table=True):
+        __tablename__ = "m2m_foo"
+        id: Optional[int] = Field(default=None, primary_key=True)
+        data: Optional[str] = None
+        type: str = Field(default="foo")
+
+        __mapper_args__ = {
+            "polymorphic_on": "type",
+            "polymorphic_identity": "foo",
+        }
+
+    class Bar(Foo, table=True):
+        __tablename__ = "m2m_bar"
+        id: Optional[int] = Field(
+            default=None, primary_key=True, foreign_key="m2m_foo.id"
+        )
+        foos: list[Foo] = Relationship(link_model=FooBarLink)
+
+        __mapper_args__ = {"polymorphic_identity": "bar"}
+
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as db:
+        b = Bar(data="bar1")
+        db.add(b)
+        db.flush()
+        bar_id = b.id
+
+        f1 = Foo(data="foo1")
+        f2 = Foo(data="foo2")
+        b.foos.append(f1)
+        b.foos.append(f2)
+        db.commit()
+
+    with Session(engine) as db:
+        b = db.get(Bar, bar_id)
+        assert b is not None
+        assert b.id == bar_id
+        assert {f.data for f in b.foos} == {"foo1", "foo2"}
+
+
+# Three-level jointed table inheritance (Foo → Bar → Blub); Blub holds two many to many collections, one to each ancestor level.
+def test_jti_m2m_three_level():
+    class BlubBarLink(SQLModel, table=True):
+        __tablename__ = "blub_bar_link"
+        blub_id: Optional[int] = Field(
+            default=None, foreign_key="m3_blub.id", primary_key=True
+        )
+        bar_id: Optional[int] = Field(
+            default=None, foreign_key="m3_bar.id", primary_key=True
+        )
+
+    class BlubFooLink(SQLModel, table=True):
+        __tablename__ = "blub_foo_link"
+        blub_id: Optional[int] = Field(
+            default=None, foreign_key="m3_blub.id", primary_key=True
+        )
+        foo_id: Optional[int] = Field(
+            default=None, foreign_key="m3_foo.id", primary_key=True
+        )
+
+    class Foo(SQLModel, table=True):
+        __tablename__ = "m3_foo"
+        id: Optional[int] = Field(default=None, primary_key=True)
+        data: Optional[str] = None
+        type: str = Field(default="foo")
+
+        __mapper_args__ = {
+            "polymorphic_on": "type",
+            "polymorphic_identity": "foo",
+        }
+
+    class Bar(Foo, table=True):
+        __tablename__ = "m3_bar"
+        id: Optional[int] = Field(
+            default=None, primary_key=True, foreign_key="m3_foo.id"
+        )
+        bar_data: Optional[str] = None
+
+        __mapper_args__ = {"polymorphic_identity": "bar"}
+
+    class Blub(Bar, table=True):
+        __tablename__ = "m3_blub"
+        id: Optional[int] = Field(
+            default=None, primary_key=True, foreign_key="m3_bar.id"
+        )
+        blub_data: Optional[str] = None
+        bars: list[Bar] = Relationship(link_model=BlubBarLink)
+        foos: list[Foo] = Relationship(link_model=BlubFooLink)
+
+        __mapper_args__ = {"polymorphic_identity": "blub"}
+
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as db:
+        f1 = Foo(data="foo1")
+        b1 = Bar(data="bar1", bar_data="bdata1")
+        b2 = Bar(data="bar2", bar_data="bdata2")
+        bl = Blub(data="blub1", blub_data="blubdata1")
+        db.add_all([f1, b1, b2, bl])
+        db.flush()
+        bl.foos.append(f1)
+        bl.bars.append(b2)
+        db.commit()
+        blub_id = bl.id
+
+    with Session(engine) as db:
+        bl = db.get(Blub, blub_id)
+        assert {f.data for f in bl.foos} == {"foo1"}
+        assert {b.data for b in bl.bars} == {"bar2"}

--- a/tests/test_polymorphic/test_poly_linked_list.py
+++ b/tests/test_polymorphic/test_poly_linked_list.py
@@ -14,11 +14,11 @@ from sqlmodel import Field, Relationship, Session, SQLModel, create_engine
 def _make_classes():
     class Node(SQLModel, table=True):
         __tablename__ = "ll_node"
-        id: Optional[int] = Field(default=None, primary_key=True)
+        id: int | None = Field(default=None, primary_key=True)
         type: str = Field(default="node")
         name: str
         # FK points to the *previous* node (my predecessor's id)
-        related_id: Optional[int] = Field(default=None, foreign_key="ll_node.id")
+        related_id: int | None = Field(default=None, foreign_key="ll_node.id")
 
         # nxt: the node whose related_id == my id (i.e. the successor)
         nxt: Optional["Node"] = Relationship(
@@ -39,16 +39,12 @@ def _make_classes():
 
     class Node2(Node, table=True):
         __tablename__ = "ll_node2"
-        id: Optional[int] = Field(
-            default=None, primary_key=True, foreign_key="ll_node.id"
-        )
+        id: int | None = Field(default=None, primary_key=True, foreign_key="ll_node.id")
         __mapper_args__ = {"polymorphic_identity": "node2"}
 
     class Node3(Node, table=True):
         __tablename__ = "ll_node3"
-        id: Optional[int] = Field(
-            default=None, primary_key=True, foreign_key="ll_node.id"
-        )
+        id: int | None = Field(default=None, primary_key=True, foreign_key="ll_node.id")
         __mapper_args__ = {"polymorphic_identity": "node3"}
 
     return Node, NodeB, Node2, Node3
@@ -86,7 +82,7 @@ def _traverse_backward(db, Node, tail_id):
 
 
 def test_linked_list_jti_chain():
-    """ nodes chain: Node → Node2 → Node → Node2 (mirrors test_one)."""
+    """nodes chain: Node → Node2 → Node → Node2 (mirrors test_one)."""
     Node, NodeB, Node2, Node3 = _make_classes()
     engine = create_engine("sqlite:///:memory:")
     SQLModel.metadata.create_all(engine)
@@ -140,7 +136,17 @@ def test_linked_list_all_four_subtypes():
         Node2(name="h"),
         Node(name="i"),
     ]
-    expected_types = ["Node2", "Node", "NodeB", "Node3", "Node3", "NodeB", "NodeB", "Node2", "Node"]
+    expected_types = [
+        "Node2",
+        "Node",
+        "NodeB",
+        "Node3",
+        "Node3",
+        "NodeB",
+        "NodeB",
+        "Node2",
+        "Node",
+    ]
     expected_names = list("abcdefghi")
 
     with Session(engine) as db:

--- a/tests/test_polymorphic/test_poly_linked_list.py
+++ b/tests/test_polymorphic/test_poly_linked_list.py
@@ -1,0 +1,172 @@
+"""Mirrors sqlalchemy/test/orm/inheritance/test_poly_linked_list.py :: PolymorphicCircularTest
+
+Node + NodeB + Node2/Node3 form a
+self-referential linked list.  related_id on Node points to the previous
+node; the nxt relationship resolves to the node whose related_id equals
+the current node's id.
+"""
+
+from typing import Optional
+
+from sqlmodel import Field, Relationship, Session, SQLModel, create_engine
+
+
+def _make_classes():
+    class Node(SQLModel, table=True):
+        __tablename__ = "ll_node"
+        id: Optional[int] = Field(default=None, primary_key=True)
+        type: str = Field(default="node")
+        name: str
+        # FK points to the *previous* node (my predecessor's id)
+        related_id: Optional[int] = Field(default=None, foreign_key="ll_node.id")
+
+        # nxt: the node whose related_id == my id (i.e. the successor)
+        nxt: Optional["Node"] = Relationship(
+            sa_relationship_kwargs={
+                "primaryjoin": "Node.id == Node.related_id",
+                "foreign_keys": "[Node.related_id]",
+                "uselist": False,
+            }
+        )
+
+        __mapper_args__ = {
+            "polymorphic_on": "type",
+            "polymorphic_identity": "node",
+        }
+
+    class NodeB(Node):
+        __mapper_args__ = {"polymorphic_identity": "nodeb"}
+
+    class Node2(Node, table=True):
+        __tablename__ = "ll_node2"
+        id: Optional[int] = Field(
+            default=None, primary_key=True, foreign_key="ll_node.id"
+        )
+        __mapper_args__ = {"polymorphic_identity": "node2"}
+
+    class Node3(Node, table=True):
+        __tablename__ = "ll_node3"
+        id: Optional[int] = Field(
+            default=None, primary_key=True, foreign_key="ll_node.id"
+        )
+        __mapper_args__ = {"polymorphic_identity": "node3"}
+
+    return Node, NodeB, Node2, Node3
+
+
+def _build_chain(db, *nodes):
+    """Persist nodes and wire nxt: nodes[0] → nodes[1] → … → nodes[-1]."""
+    db.add_all(nodes)
+    db.flush()
+    for i in range(len(nodes) - 1):
+        nodes[i].nxt = nodes[i + 1]
+    db.commit()
+    return nodes[0].id, nodes[-1].id
+
+
+def _traverse_forward(db, Node, head_id):
+    node = db.get(Node, head_id)
+    names, types = [], []
+    while node:
+        names.append(node.name)
+        types.append(type(node).__name__)
+        node = node.nxt
+    return names, types
+
+
+def _traverse_backward(db, Node, tail_id):
+    node = db.get(Node, tail_id)
+    names = []
+    while node:
+        names.append(node.name)
+        if node.related_id is None:
+            break
+        node = db.get(Node, node.related_id)
+    return names
+
+
+def test_linked_list_jti_chain():
+    """ nodes chain: Node → Node2 → Node → Node2 (mirrors test_one)."""
+    Node, NodeB, Node2, Node3 = _make_classes()
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as db:
+        head_id, tail_id = _build_chain(
+            db, Node(name="n1"), Node2(name="n2"), Node(name="n3"), Node2(name="n4")
+        )
+
+    with Session(engine) as db:
+        names, types = _traverse_forward(db, Node, head_id)
+        assert names == ["n1", "n2", "n3", "n4"]
+        assert types == ["Node", "Node2", "Node", "Node2"]
+
+        assert _traverse_backward(db, Node, tail_id) == ["n4", "n3", "n2", "n1"]
+
+
+def test_linked_list_single_jti_node():
+    """Single jointed table inheritance node has no successor (mirrors test_two)."""
+    Node, NodeB, Node2, Node3 = _make_classes()
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as db:
+        n = Node3(name="only")
+        db.add(n)
+        db.commit()
+        nid = n.id
+
+    with Session(engine) as db:
+        n = db.get(Node, nid)
+        assert isinstance(n, Node3)
+        assert n.nxt is None
+        assert n.related_id is None
+
+
+def test_linked_list_all_four_subtypes():
+    """Chain mixing all four subtypes traverses correctly (mirrors test_three)."""
+    Node, NodeB, Node2, Node3 = _make_classes()
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+
+    chain = [
+        Node2(name="a"),
+        Node(name="b"),
+        NodeB(name="c"),
+        Node3(name="d"),
+        Node3(name="e"),
+        NodeB(name="f"),
+        NodeB(name="g"),
+        Node2(name="h"),
+        Node(name="i"),
+    ]
+    expected_types = ["Node2", "Node", "NodeB", "Node3", "Node3", "NodeB", "NodeB", "Node2", "Node"]
+    expected_names = list("abcdefghi")
+
+    with Session(engine) as db:
+        head_id, tail_id = _build_chain(db, *chain)
+
+    with Session(engine) as db:
+        names, types = _traverse_forward(db, Node, head_id)
+        assert names == expected_names
+        assert types == expected_types
+
+        assert _traverse_backward(db, Node, tail_id) == list(reversed(expected_names))
+
+
+def test_linked_list_sti_node_in_jti_chain():
+    """Single table inheritance node (NodeB) appears correctly typed when retrieved via base class."""
+    Node, NodeB, Node2, Node3 = _make_classes()
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as db:
+        head_id, _ = _build_chain(
+            db, Node2(name="start"), NodeB(name="middle"), Node3(name="end")
+        )
+
+    with Session(engine) as db:
+        head = db.get(Node, head_id)
+        assert isinstance(head, Node2)
+        assert isinstance(head.nxt, NodeB)
+        assert isinstance(head.nxt.nxt, Node3)

--- a/tests/test_polymorphic/test_poly_persistence.py
+++ b/tests/test_polymorphic/test_poly_persistence.py
@@ -1,0 +1,214 @@
+"""Mirrors sqlalchemy/test/orm/inheritance/test_poly_persistence.py :: InsertOrderTest, RoundTripTest"""
+
+from types import SimpleNamespace
+from typing import Optional
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import mapped_column, with_polymorphic
+from sqlmodel import Field, Relationship, Session, SQLModel, create_engine, select
+
+
+def _make_classes():
+    class Company(SQLModel, table=True):
+        __tablename__ = "companies"
+        company_id: Optional[int] = Field(default=None, primary_key=True)
+        name: str
+        employees: list["Person"] = Relationship(back_populates="company")
+
+    class Person(SQLModel, table=True):
+        __tablename__ = "people"
+        person_id: Optional[int] = Field(default=None, primary_key=True)
+        company_id: Optional[int] = Field(
+            default=None, foreign_key="companies.company_id"
+        )
+        name: str
+        type: str = Field(default="person")
+        company: Optional[Company] = Relationship(back_populates="employees")
+
+        __mapper_args__ = {
+            "polymorphic_on": "type",
+            "polymorphic_identity": "person",
+        }
+
+    class Engineer(Person):
+        __tablename__ = "engineers"
+        person_id: Optional[int] = Field(
+            default=None, primary_key=True, foreign_key="people.person_id"
+        )
+        status: Optional[str] = Field(default=None, sa_column=mapped_column(nullable=True))
+        engineer_name: Optional[str] = Field(default=None, sa_column=mapped_column(nullable=True))
+        primary_language: Optional[str] = Field(default=None, sa_column=mapped_column(nullable=True))
+
+        __mapper_args__ = {"polymorphic_identity": "engineer"}
+
+    class Manager(Person):
+        __tablename__ = "managers"
+        person_id: Optional[int] = Field(
+            default=None, primary_key=True, foreign_key="people.person_id"
+        )
+        status: Optional[str] = Field(default=None, sa_column=mapped_column(nullable=True))
+        manager_name: Optional[str] = Field(default=None, sa_column=mapped_column(nullable=True))
+
+        __mapper_args__ = {"polymorphic_identity": "manager"}
+
+    class Boss(Manager):
+        __tablename__ = "boss"
+        person_id: Optional[int] = Field(
+            default=None, primary_key=True, foreign_key="managers.person_id"
+        )
+        golf_swing: Optional[str] = Field(default=None, sa_column=mapped_column(nullable=True))
+
+        __mapper_args__ = {"polymorphic_identity": "boss"}
+
+    return Company, Person, Engineer, Manager, Boss
+
+
+def _seed(engine, Company, Engineer, Manager):
+    with Session(engine) as db:
+        c = Company(name="company1")
+        db.add(c)
+        db.flush()
+        cid = c.company_id
+        db.add(Manager(name="pointy haired boss", status="AAB", manager_name="manager1", company_id=cid))
+        db.add(Engineer(name="dilbert", status="BBA", engineer_name="engineer1", primary_language="java", company_id=cid))
+        db.add(Engineer(name="wally", status="CGG", engineer_name="engineer2", primary_language="python", company_id=cid))
+        db.add(Manager(name="jsmith", status="ABA", manager_name="manager2", company_id=cid))
+        db.commit()
+    return SimpleNamespace(company_id=cid)
+
+
+def test_insert_order():
+    # mirrors InsertOrderTest.test_insert_order
+    Company, Person, Engineer, Manager, Boss = _make_classes()
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as db:
+        c = Company(name="company1")
+        db.add(c)
+        db.flush()
+        cid = c.company_id
+        db.add(Manager(name="pointy haired boss", status="AAB", manager_name="manager1", company_id=cid))
+        db.add(Engineer(name="dilbert", status="BBA", engineer_name="engineer1", primary_language="java", company_id=cid))
+        db.add(Engineer(name="wally", status="CGG", engineer_name="engineer2", primary_language="python", company_id=cid))
+        db.add(Manager(name="jsmith", status="ABA", manager_name="manager2", company_id=cid))
+        db.commit()
+
+    with Session(engine) as db:
+        employees = db.exec(select(Person)).all()
+
+    assert len(employees) == 4
+    assert sum(isinstance(e, Manager) for e in employees) == 2
+    assert sum(isinstance(e, Engineer) for e in employees) == 2
+
+
+def test_lazy_load():
+    # mirrors RoundTripTest.test_lazy_load
+    Company, Person, Engineer, Manager, Boss = _make_classes()
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+    c = _seed(engine, Company, Engineer, Manager)
+
+    with Session(engine) as db:
+        company = db.get(Company, c.company_id)
+        employees = company.employees
+
+    assert len(employees) == 4
+    assert {type(e) for e in employees} == {Engineer, Manager}
+
+
+def test_with_polymorphic_eager_load():
+    # mirrors RoundTripTest with with_polymorphic='auto' configuration
+    Company, Person, Engineer, Manager, Boss = _make_classes()
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+    _seed(engine, Company, Engineer, Manager)
+
+    with Session(engine) as db:
+        poly = with_polymorphic(Person, [Engineer, Manager])
+        results = db.exec(select(poly)).all()
+
+    assert len(results) == 4
+    engineers = [r for r in results if isinstance(r, Engineer)]
+    managers = [r for r in results if isinstance(r, Manager)]
+    assert len(engineers) == 2
+    assert len(managers) == 2
+    assert engineers[0].primary_language in {"java", "python"}
+    assert managers[0].manager_name in {"manager1", "manager2"}
+
+
+def test_standalone_orphans():
+    # mirrors RoundTripTest.test_standalone_orphans
+    class Company2(SQLModel, table=True):
+        __tablename__ = "companies2"
+        company_id: Optional[int] = Field(default=None, primary_key=True)
+        name: str
+
+    class Person2(SQLModel, table=True):
+        __tablename__ = "people2"
+        person_id: Optional[int] = Field(default=None, primary_key=True)
+        company_id: Optional[int] = Field(
+            default=None, sa_column=mapped_column(nullable=False)
+        )
+        name: str
+        type: str = Field(default="person")
+
+        __mapper_args__ = {
+            "polymorphic_on": "type",
+            "polymorphic_identity": "person",
+        }
+
+    class Manager2(Person2):
+        __tablename__ = "managers2"
+        person_id: Optional[int] = Field(
+            default=None, primary_key=True, foreign_key="people2.person_id"
+        )
+        manager_name: Optional[str] = Field(default=None, sa_column=mapped_column(nullable=True))
+
+        __mapper_args__ = {"polymorphic_identity": "manager"}
+
+    class Boss2(Manager2):
+        __tablename__ = "boss2"
+        person_id: Optional[int] = Field(
+            default=None, primary_key=True, foreign_key="managers2.person_id"
+        )
+        golf_swing: Optional[str] = Field(default=None, sa_column=mapped_column(nullable=True))
+
+        __mapper_args__ = {"polymorphic_identity": "boss"}
+
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+
+    with pytest.raises(IntegrityError):
+        with Session(engine) as db:
+            daboss = Boss2(name="daboss", manager_name="boss", golf_swing="fore")
+            db.add(daboss)
+            db.flush()
+
+
+def test_multi_level_three_tables():
+    # mirrors RoundTripTest — select(Person) returns all levels; select(Manager) includes Boss
+    Company, Person, Engineer, Manager, Boss = _make_classes()
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as db:
+        c = Company(name="corp")
+        db.add(c)
+        db.flush()
+        cid = c.company_id
+        db.add(Manager(name="mgr", manager_name="middle mgr", company_id=cid))
+        db.add(Boss(name="boss", manager_name="top boss", golf_swing="fore", company_id=cid))
+        db.commit()
+
+    with Session(engine) as db:
+        people = db.exec(select(Person)).all()
+        managers = db.exec(select(Manager)).all()
+        bosses = db.exec(select(Boss)).all()
+
+    assert len(people) == 2
+    assert len(managers) == 2  # Manager + Boss
+    assert len(bosses) == 1
+    assert isinstance(bosses[0], Boss)
+    assert {type(p) for p in people} == {Manager, Boss}

--- a/tests/test_polymorphic/test_poly_persistence.py
+++ b/tests/test_polymorphic/test_poly_persistence.py
@@ -1,7 +1,6 @@
 """Mirrors sqlalchemy/test/orm/inheritance/test_poly_persistence.py :: InsertOrderTest, RoundTripTest"""
 
 from types import SimpleNamespace
-from typing import Optional
 
 import pytest
 from sqlalchemy.exc import IntegrityError
@@ -12,19 +11,17 @@ from sqlmodel import Field, Relationship, Session, SQLModel, create_engine, sele
 def _make_classes():
     class Company(SQLModel, table=True):
         __tablename__ = "companies"
-        company_id: Optional[int] = Field(default=None, primary_key=True)
+        company_id: int | None = Field(default=None, primary_key=True)
         name: str
         employees: list["Person"] = Relationship(back_populates="company")
 
     class Person(SQLModel, table=True):
         __tablename__ = "people"
-        person_id: Optional[int] = Field(default=None, primary_key=True)
-        company_id: Optional[int] = Field(
-            default=None, foreign_key="companies.company_id"
-        )
+        person_id: int | None = Field(default=None, primary_key=True)
+        company_id: int | None = Field(default=None, foreign_key="companies.company_id")
         name: str
         type: str = Field(default="person")
-        company: Optional[Company] = Relationship(back_populates="employees")
+        company: Company | None = Relationship(back_populates="employees")
 
         __mapper_args__ = {
             "polymorphic_on": "type",
@@ -33,31 +30,39 @@ def _make_classes():
 
     class Engineer(Person):
         __tablename__ = "engineers"
-        person_id: Optional[int] = Field(
+        person_id: int | None = Field(
             default=None, primary_key=True, foreign_key="people.person_id"
         )
-        status: Optional[str] = Field(default=None, sa_column=mapped_column(nullable=True))
-        engineer_name: Optional[str] = Field(default=None, sa_column=mapped_column(nullable=True))
-        primary_language: Optional[str] = Field(default=None, sa_column=mapped_column(nullable=True))
+        status: str | None = Field(default=None, sa_column=mapped_column(nullable=True))
+        engineer_name: str | None = Field(
+            default=None, sa_column=mapped_column(nullable=True)
+        )
+        primary_language: str | None = Field(
+            default=None, sa_column=mapped_column(nullable=True)
+        )
 
         __mapper_args__ = {"polymorphic_identity": "engineer"}
 
     class Manager(Person):
         __tablename__ = "managers"
-        person_id: Optional[int] = Field(
+        person_id: int | None = Field(
             default=None, primary_key=True, foreign_key="people.person_id"
         )
-        status: Optional[str] = Field(default=None, sa_column=mapped_column(nullable=True))
-        manager_name: Optional[str] = Field(default=None, sa_column=mapped_column(nullable=True))
+        status: str | None = Field(default=None, sa_column=mapped_column(nullable=True))
+        manager_name: str | None = Field(
+            default=None, sa_column=mapped_column(nullable=True)
+        )
 
         __mapper_args__ = {"polymorphic_identity": "manager"}
 
     class Boss(Manager):
         __tablename__ = "boss"
-        person_id: Optional[int] = Field(
+        person_id: int | None = Field(
             default=None, primary_key=True, foreign_key="managers.person_id"
         )
-        golf_swing: Optional[str] = Field(default=None, sa_column=mapped_column(nullable=True))
+        golf_swing: str | None = Field(
+            default=None, sa_column=mapped_column(nullable=True)
+        )
 
         __mapper_args__ = {"polymorphic_identity": "boss"}
 
@@ -70,10 +75,37 @@ def _seed(engine, Company, Engineer, Manager):
         db.add(c)
         db.flush()
         cid = c.company_id
-        db.add(Manager(name="pointy haired boss", status="AAB", manager_name="manager1", company_id=cid))
-        db.add(Engineer(name="dilbert", status="BBA", engineer_name="engineer1", primary_language="java", company_id=cid))
-        db.add(Engineer(name="wally", status="CGG", engineer_name="engineer2", primary_language="python", company_id=cid))
-        db.add(Manager(name="jsmith", status="ABA", manager_name="manager2", company_id=cid))
+        db.add(
+            Manager(
+                name="pointy haired boss",
+                status="AAB",
+                manager_name="manager1",
+                company_id=cid,
+            )
+        )
+        db.add(
+            Engineer(
+                name="dilbert",
+                status="BBA",
+                engineer_name="engineer1",
+                primary_language="java",
+                company_id=cid,
+            )
+        )
+        db.add(
+            Engineer(
+                name="wally",
+                status="CGG",
+                engineer_name="engineer2",
+                primary_language="python",
+                company_id=cid,
+            )
+        )
+        db.add(
+            Manager(
+                name="jsmith", status="ABA", manager_name="manager2", company_id=cid
+            )
+        )
         db.commit()
     return SimpleNamespace(company_id=cid)
 
@@ -89,10 +121,37 @@ def test_insert_order():
         db.add(c)
         db.flush()
         cid = c.company_id
-        db.add(Manager(name="pointy haired boss", status="AAB", manager_name="manager1", company_id=cid))
-        db.add(Engineer(name="dilbert", status="BBA", engineer_name="engineer1", primary_language="java", company_id=cid))
-        db.add(Engineer(name="wally", status="CGG", engineer_name="engineer2", primary_language="python", company_id=cid))
-        db.add(Manager(name="jsmith", status="ABA", manager_name="manager2", company_id=cid))
+        db.add(
+            Manager(
+                name="pointy haired boss",
+                status="AAB",
+                manager_name="manager1",
+                company_id=cid,
+            )
+        )
+        db.add(
+            Engineer(
+                name="dilbert",
+                status="BBA",
+                engineer_name="engineer1",
+                primary_language="java",
+                company_id=cid,
+            )
+        )
+        db.add(
+            Engineer(
+                name="wally",
+                status="CGG",
+                engineer_name="engineer2",
+                primary_language="python",
+                company_id=cid,
+            )
+        )
+        db.add(
+            Manager(
+                name="jsmith", status="ABA", manager_name="manager2", company_id=cid
+            )
+        )
         db.commit()
 
     with Session(engine) as db:
@@ -142,13 +201,13 @@ def test_standalone_orphans():
     # mirrors RoundTripTest.test_standalone_orphans
     class Company2(SQLModel, table=True):
         __tablename__ = "companies2"
-        company_id: Optional[int] = Field(default=None, primary_key=True)
+        company_id: int | None = Field(default=None, primary_key=True)
         name: str
 
     class Person2(SQLModel, table=True):
         __tablename__ = "people2"
-        person_id: Optional[int] = Field(default=None, primary_key=True)
-        company_id: Optional[int] = Field(
+        person_id: int | None = Field(default=None, primary_key=True)
+        company_id: int | None = Field(
             default=None, sa_column=mapped_column(nullable=False)
         )
         name: str
@@ -161,19 +220,23 @@ def test_standalone_orphans():
 
     class Manager2(Person2):
         __tablename__ = "managers2"
-        person_id: Optional[int] = Field(
+        person_id: int | None = Field(
             default=None, primary_key=True, foreign_key="people2.person_id"
         )
-        manager_name: Optional[str] = Field(default=None, sa_column=mapped_column(nullable=True))
+        manager_name: str | None = Field(
+            default=None, sa_column=mapped_column(nullable=True)
+        )
 
         __mapper_args__ = {"polymorphic_identity": "manager"}
 
     class Boss2(Manager2):
         __tablename__ = "boss2"
-        person_id: Optional[int] = Field(
+        person_id: int | None = Field(
             default=None, primary_key=True, foreign_key="managers2.person_id"
         )
-        golf_swing: Optional[str] = Field(default=None, sa_column=mapped_column(nullable=True))
+        golf_swing: str | None = Field(
+            default=None, sa_column=mapped_column(nullable=True)
+        )
 
         __mapper_args__ = {"polymorphic_identity": "boss"}
 
@@ -199,7 +262,11 @@ def test_multi_level_three_tables():
         db.flush()
         cid = c.company_id
         db.add(Manager(name="mgr", manager_name="middle mgr", company_id=cid))
-        db.add(Boss(name="boss", manager_name="top boss", golf_swing="fore", company_id=cid))
+        db.add(
+            Boss(
+                name="boss", manager_name="top boss", golf_swing="fore", company_id=cid
+            )
+        )
         db.commit()
 
     with Session(engine) as db:

--- a/tests/test_polymorphic/test_poly_query.py
+++ b/tests/test_polymorphic/test_poly_query.py
@@ -1,0 +1,327 @@
+"""
+Tests the polymorphic query operators that operate above SQLModel's layer
+(selectin_polymorphic, with_polymorphic, of_type) to confirm that SQLModel's
+metaclass produces a mapper config compatible with them.
+"""
+
+from typing import Optional
+
+import pytest
+from sqlalchemy import or_
+from sqlalchemy.orm import selectin_polymorphic, selectinload, with_polymorphic
+from sqlmodel import Field, Relationship, Session, SQLModel, create_engine, select
+
+
+def _make_classes():
+    class Company(SQLModel, table=True):
+        __tablename__ = "qg_company"
+        id: Optional[int] = Field(default=None, primary_key=True)
+        name: str
+        employees: list["Employee"] = Relationship(back_populates="company")
+
+    class Employee(SQLModel, table=True):
+        __tablename__ = "qg_employee"
+        id: Optional[int] = Field(default=None, primary_key=True)
+        name: str
+        type: str = Field(default="employee")
+        company_id: Optional[int] = Field(default=None, foreign_key="qg_company.id")
+        company: Optional[Company] = Relationship(back_populates="employees")
+
+        __mapper_args__ = {
+            "polymorphic_on": "type",
+            "polymorphic_identity": "employee",
+        }
+
+    class Manager(Employee, table=True):
+        __tablename__ = "qg_manager"
+        id: Optional[int] = Field(
+            default=None, primary_key=True, foreign_key="qg_employee.id"
+        )
+        manager_name: Optional[str] = None
+        paperwork: list["Paperwork"] = Relationship(back_populates="manager")
+
+        __mapper_args__ = {"polymorphic_identity": "manager"}
+
+    class Engineer(Employee, table=True):
+        __tablename__ = "qg_engineer"
+        id: Optional[int] = Field(
+            default=None, primary_key=True, foreign_key="qg_employee.id"
+        )
+        engineer_info: Optional[str] = None
+
+        __mapper_args__ = {"polymorphic_identity": "engineer"}
+
+    class Paperwork(SQLModel, table=True):
+        __tablename__ = "qg_paperwork"
+        id: Optional[int] = Field(default=None, primary_key=True)
+        manager_id: Optional[int] = Field(
+            default=None, foreign_key="qg_manager.id"
+        )
+        document_name: str
+        manager: Optional[Manager] = Relationship(back_populates="paperwork")
+
+    return Company, Employee, Manager, Engineer, Paperwork
+
+
+def _make_deep_classes():
+    Company, Employee, Manager, Engineer, Paperwork = _make_classes()
+
+    class SeniorEngineer(Engineer, table=True):
+        __tablename__ = "qg_senior_engineer"
+        id: Optional[int] = Field(
+            default=None, primary_key=True, foreign_key="qg_engineer.id"
+        )
+        years_experience: Optional[int] = None
+
+        __mapper_args__ = {"polymorphic_identity": "senior_engineer"}
+
+    return Company, Employee, Manager, Engineer, SeniorEngineer, Paperwork
+
+
+def _seed(engine, Company, Manager, Engineer, Paperwork):
+    with Session(engine) as db:
+        db.add(
+            Company(
+                name="Krusty Krab",
+                employees=[
+                    Manager(
+                        name="Mr. Krabs",
+                        manager_name="Eugene H. Krabs",
+                        paperwork=[
+                            Paperwork(document_name="Secret Recipes"),
+                            Paperwork(document_name="Krabby Patty Orders"),
+                        ],
+                    ),
+                    Engineer(name="SpongeBob", engineer_info="Krabby Patty Master"),
+                    Engineer(
+                        name="Squidward",
+                        engineer_info="Senior Customer Engagement Engineer",
+                    ),
+                ],
+            )
+        )
+        db.commit()
+
+
+# test selectin_polymorphic
+def test_selectin_polymorphic_eager_loads_subclass_attrs():
+    """selectin_polymorphic fires extra SELECTs so subclass attrs are already
+    loaded when accessed — no additional lazy load per object."""
+    Company, Employee, Manager, Engineer, Paperwork = _make_classes()
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+    _seed(engine, Company, Manager, Engineer, Paperwork)
+
+    with Session(engine) as db:
+        stmt = (
+            select(Employee)
+            .order_by(Employee.id)
+            .options(selectin_polymorphic(Employee, [Manager, Engineer]))
+        )
+        employees = db.exec(stmt).all()
+        assert len(employees) == 3
+        mgr = employees[0]
+        assert isinstance(mgr, Manager)
+        assert mgr.manager_name == "Eugene H. Krabs"
+        eng = employees[1]
+        assert isinstance(eng, Engineer)
+        assert eng.engineer_info == "Krabby Patty Master"
+
+
+def test_selectin_polymorphic_via_relationship():
+    """selectin_polymorphic chained on selectinload eager-loads subclass attrs
+    through a relationship (mirrors the Company.employees example in the docs)."""
+    Company, Employee, Manager, Engineer, Paperwork = _make_classes()
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+    _seed(engine, Company, Manager, Engineer, Paperwork)
+
+    with Session(engine) as db:
+        stmt = select(Company).options(
+            selectinload(Company.employees).selectin_polymorphic([Manager, Engineer])
+        )
+        companies = db.exec(stmt).all()
+        assert len(companies) == 1
+        employees = companies[0].employees
+        assert len(employees) == 3
+        mgr = next(e for e in employees if isinstance(e, Manager))
+        assert mgr.manager_name == "Eugene H. Krabs"
+
+
+# test with_polymorphic
+
+
+def test_with_polymorphic_filter_by_subclass_attr():
+    """with_polymorphic exposes subclass namespaces so WHERE clauses can
+    reference columns from multiple sub-tables at once."""
+    Company, Employee, Manager, Engineer, Paperwork = _make_classes()
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+    _seed(engine, Company, Manager, Engineer, Paperwork)
+
+    with Session(engine) as db:
+        poly = with_polymorphic(Employee, [Manager, Engineer])
+        stmt = select(poly).where(
+            or_(
+                poly.Manager.manager_name == "Eugene H. Krabs",
+                poly.Engineer.engineer_info == "Senior Customer Engagement Engineer",
+            )
+        )
+        results = db.exec(stmt).all()
+        assert len(results) == 2
+        names = {r.name for r in results}
+        assert names == {"Mr. Krabs", "Squidward"}
+
+
+# test of_type — joining to specific sub-types
+def test_of_type_join_filters_to_subclass():
+    """Company.employees.of_type(Engineer) inner-joins only the engineer
+    sub-table, allowing WHERE on engineer-specific columns."""
+    Company, Employee, Manager, Engineer, Paperwork = _make_classes()
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+    _seed(engine, Company, Manager, Engineer, Paperwork)
+
+    with Session(engine) as db:
+        stmt = (
+            select(Company.name, Engineer.name)
+            .join(Company.employees.of_type(Engineer))
+            .where(
+                or_(
+                    Engineer.name == "SpongeBob",
+                    Engineer.engineer_info == "Senior Customer Engagement Engineer",
+                )
+            )
+        )
+        rows = db.exec(stmt).all()
+        assert len(rows) == 2
+        emp_names = {r[1] for r in rows}
+        assert emp_names == {"SpongeBob", "Squidward"}
+
+
+def test_of_type_eager_load_with_polymorphic():
+    """selectinload(Company.employees.of_type(with_polymorphic('*')))
+    eagerly loads all employees with all subclass columns in one shot."""
+    Company, Employee, Manager, Engineer, Paperwork = _make_classes()
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+    _seed(engine, Company, Manager, Engineer, Paperwork)
+
+    with Session(engine) as db:
+        all_employees = with_polymorphic(Employee, "*")
+        stmt = select(Company).options(
+            selectinload(Company.employees.of_type(all_employees))
+        )
+        companies = db.exec(stmt).all()
+        employees = companies[0].employees
+        assert len(employees) == 3
+        mgr = next(e for e in employees if isinstance(e, Manager))
+        assert mgr.manager_name == "Eugene H. Krabs"
+
+
+# test selectin_polymorphic combined with selectinload on subclass relationship
+def test_selectin_polymorphic_with_sibling_selectinload():
+    """selectin_polymorphic and selectinload(Manager.paperwork) as sibling
+    options both fire; Manager instances have paperwork eagerly loaded."""
+    Company, Employee, Manager, Engineer, Paperwork = _make_classes()
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+    _seed(engine, Company, Manager, Engineer, Paperwork)
+
+    with Session(engine) as db:
+        stmt = (
+            select(Employee)
+            .order_by(Employee.id)
+            .options(
+                selectin_polymorphic(Employee, [Manager, Engineer]),
+                selectinload(Manager.paperwork),
+            )
+        )
+        employees = db.exec(stmt).all()
+        mgr = next(e for e in employees if isinstance(e, Manager))
+        assert isinstance(mgr, Manager)
+        assert {p.document_name for p in mgr.paperwork} == {
+            "Secret Recipes",
+            "Krabby Patty Orders",
+        }
+
+
+def _seed_deep(engine, Company, Manager, Engineer, SeniorEngineer, Paperwork):
+    with Session(engine) as db:
+        db.add(
+            Company(
+                name="Krusty Krab",
+                employees=[
+                    Manager(
+                        name="Mr. Krabs",
+                        manager_name="Eugene H. Krabs",
+                        paperwork=[Paperwork(document_name="Secret Recipes")],
+                    ),
+                    Engineer(name="SpongeBob", engineer_info="Krabby Patty Master"),
+                    SeniorEngineer(
+                        name="Sandy",
+                        engineer_info="Aquatic Research",
+                        years_experience=10,
+                    ),
+                ],
+            )
+        )
+        db.commit()
+
+
+# three-level joined-table inheritance query tests
+
+def test_three_level_selectin_polymorphic_loads_deepest_subclass():
+    """selectin_polymorphic on a 3-level hierarchy eagerly loads the deepest
+    subclass attrs without an extra lazy load."""
+    Company, Employee, Manager, Engineer, SeniorEngineer, Paperwork = _make_deep_classes()
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+    _seed_deep(engine, Company, Manager, Engineer, SeniorEngineer, Paperwork)
+
+    with Session(engine) as db:
+        stmt = (
+            select(Employee)
+            .order_by(Employee.id)
+            .options(selectin_polymorphic(Employee, [Manager, Engineer, SeniorEngineer]))
+        )
+        employees = db.exec(stmt).all()
+        assert len(employees) == 3
+        senior = next(e for e in employees if isinstance(e, SeniorEngineer))
+        assert senior.name == "Sandy"
+        assert senior.engineer_info == "Aquatic Research"
+        assert senior.years_experience == 10
+
+
+def test_three_level_with_polymorphic_filters_on_deepest_column():
+    """with_polymorphic exposes the third-level sub-table so a WHERE clause
+    can reference years_experience without a separate join step."""
+    Company, Employee, Manager, Engineer, SeniorEngineer, Paperwork = _make_deep_classes()
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+    _seed_deep(engine, Company, Manager, Engineer, SeniorEngineer, Paperwork)
+
+    with Session(engine) as db:
+        poly = with_polymorphic(Employee, [Manager, Engineer, SeniorEngineer])
+        stmt = select(poly).where(poly.SeniorEngineer.years_experience > 5)
+        results = db.exec(stmt).all()
+        assert len(results) == 1
+        assert results[0].name == "Sandy"
+
+
+def test_three_level_of_type_joins_through_all_tables():
+    """of_type(SeniorEngineer) on a base relationship joins through both
+    intermediate tables and returns only the deepest subclass rows."""
+    Company, Employee, Manager, Engineer, SeniorEngineer, Paperwork = _make_deep_classes()
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+    _seed_deep(engine, Company, Manager, Engineer, SeniorEngineer, Paperwork)
+
+    with Session(engine) as db:
+        stmt = (
+            select(Company.name, SeniorEngineer.name)
+            .join(Company.employees.of_type(SeniorEngineer))
+        )
+        rows = db.exec(stmt).all()
+        assert len(rows) == 1
+        assert rows[0][1] == "Sandy"

--- a/tests/test_polymorphic/test_poly_query.py
+++ b/tests/test_polymorphic/test_poly_query.py
@@ -4,9 +4,6 @@ Tests the polymorphic query operators that operate above SQLModel's layer
 metaclass produces a mapper config compatible with them.
 """
 
-from typing import Optional
-
-import pytest
 from sqlalchemy import or_
 from sqlalchemy.orm import selectin_polymorphic, selectinload, with_polymorphic
 from sqlmodel import Field, Relationship, Session, SQLModel, create_engine, select
@@ -15,17 +12,17 @@ from sqlmodel import Field, Relationship, Session, SQLModel, create_engine, sele
 def _make_classes():
     class Company(SQLModel, table=True):
         __tablename__ = "qg_company"
-        id: Optional[int] = Field(default=None, primary_key=True)
+        id: int | None = Field(default=None, primary_key=True)
         name: str
         employees: list["Employee"] = Relationship(back_populates="company")
 
     class Employee(SQLModel, table=True):
         __tablename__ = "qg_employee"
-        id: Optional[int] = Field(default=None, primary_key=True)
+        id: int | None = Field(default=None, primary_key=True)
         name: str
         type: str = Field(default="employee")
-        company_id: Optional[int] = Field(default=None, foreign_key="qg_company.id")
-        company: Optional[Company] = Relationship(back_populates="employees")
+        company_id: int | None = Field(default=None, foreign_key="qg_company.id")
+        company: Company | None = Relationship(back_populates="employees")
 
         __mapper_args__ = {
             "polymorphic_on": "type",
@@ -34,31 +31,29 @@ def _make_classes():
 
     class Manager(Employee, table=True):
         __tablename__ = "qg_manager"
-        id: Optional[int] = Field(
+        id: int | None = Field(
             default=None, primary_key=True, foreign_key="qg_employee.id"
         )
-        manager_name: Optional[str] = None
+        manager_name: str | None = None
         paperwork: list["Paperwork"] = Relationship(back_populates="manager")
 
         __mapper_args__ = {"polymorphic_identity": "manager"}
 
     class Engineer(Employee, table=True):
         __tablename__ = "qg_engineer"
-        id: Optional[int] = Field(
+        id: int | None = Field(
             default=None, primary_key=True, foreign_key="qg_employee.id"
         )
-        engineer_info: Optional[str] = None
+        engineer_info: str | None = None
 
         __mapper_args__ = {"polymorphic_identity": "engineer"}
 
     class Paperwork(SQLModel, table=True):
         __tablename__ = "qg_paperwork"
-        id: Optional[int] = Field(default=None, primary_key=True)
-        manager_id: Optional[int] = Field(
-            default=None, foreign_key="qg_manager.id"
-        )
+        id: int | None = Field(default=None, primary_key=True)
+        manager_id: int | None = Field(default=None, foreign_key="qg_manager.id")
         document_name: str
-        manager: Optional[Manager] = Relationship(back_populates="paperwork")
+        manager: Manager | None = Relationship(back_populates="paperwork")
 
     return Company, Employee, Manager, Engineer, Paperwork
 
@@ -68,10 +63,10 @@ def _make_deep_classes():
 
     class SeniorEngineer(Engineer, table=True):
         __tablename__ = "qg_senior_engineer"
-        id: Optional[int] = Field(
+        id: int | None = Field(
             default=None, primary_key=True, foreign_key="qg_engineer.id"
         )
-        years_experience: Optional[int] = None
+        years_experience: int | None = None
 
         __mapper_args__ = {"polymorphic_identity": "senior_engineer"}
 
@@ -271,10 +266,13 @@ def _seed_deep(engine, Company, Manager, Engineer, SeniorEngineer, Paperwork):
 
 # three-level joined-table inheritance query tests
 
+
 def test_three_level_selectin_polymorphic_loads_deepest_subclass():
     """selectin_polymorphic on a 3-level hierarchy eagerly loads the deepest
     subclass attrs without an extra lazy load."""
-    Company, Employee, Manager, Engineer, SeniorEngineer, Paperwork = _make_deep_classes()
+    Company, Employee, Manager, Engineer, SeniorEngineer, Paperwork = (
+        _make_deep_classes()
+    )
     engine = create_engine("sqlite:///:memory:")
     SQLModel.metadata.create_all(engine)
     _seed_deep(engine, Company, Manager, Engineer, SeniorEngineer, Paperwork)
@@ -283,7 +281,9 @@ def test_three_level_selectin_polymorphic_loads_deepest_subclass():
         stmt = (
             select(Employee)
             .order_by(Employee.id)
-            .options(selectin_polymorphic(Employee, [Manager, Engineer, SeniorEngineer]))
+            .options(
+                selectin_polymorphic(Employee, [Manager, Engineer, SeniorEngineer])
+            )
         )
         employees = db.exec(stmt).all()
         assert len(employees) == 3
@@ -296,7 +296,9 @@ def test_three_level_selectin_polymorphic_loads_deepest_subclass():
 def test_three_level_with_polymorphic_filters_on_deepest_column():
     """with_polymorphic exposes the third-level sub-table so a WHERE clause
     can reference years_experience without a separate join step."""
-    Company, Employee, Manager, Engineer, SeniorEngineer, Paperwork = _make_deep_classes()
+    Company, Employee, Manager, Engineer, SeniorEngineer, Paperwork = (
+        _make_deep_classes()
+    )
     engine = create_engine("sqlite:///:memory:")
     SQLModel.metadata.create_all(engine)
     _seed_deep(engine, Company, Manager, Engineer, SeniorEngineer, Paperwork)
@@ -312,15 +314,16 @@ def test_three_level_with_polymorphic_filters_on_deepest_column():
 def test_three_level_of_type_joins_through_all_tables():
     """of_type(SeniorEngineer) on a base relationship joins through both
     intermediate tables and returns only the deepest subclass rows."""
-    Company, Employee, Manager, Engineer, SeniorEngineer, Paperwork = _make_deep_classes()
+    Company, Employee, Manager, Engineer, SeniorEngineer, Paperwork = (
+        _make_deep_classes()
+    )
     engine = create_engine("sqlite:///:memory:")
     SQLModel.metadata.create_all(engine)
     _seed_deep(engine, Company, Manager, Engineer, SeniorEngineer, Paperwork)
 
     with Session(engine) as db:
-        stmt = (
-            select(Company.name, SeniorEngineer.name)
-            .join(Company.employees.of_type(SeniorEngineer))
+        stmt = select(Company.name, SeniorEngineer.name).join(
+            Company.employees.of_type(SeniorEngineer)
         )
         rows = db.exec(stmt).all()
         assert len(rows) == 1

--- a/tests/test_polymorphic/test_poly_relationships.py
+++ b/tests/test_polymorphic/test_poly_relationships.py
@@ -15,7 +15,7 @@ from sqlmodel import Field, Relationship, Session, SQLModel, create_engine, sele
 def _make_person_engineer_classes():
     class Person(SQLModel, table=True):
         __tablename__ = "rel_person"
-        id: Optional[int] = Field(default=None, primary_key=True)
+        id: int | None = Field(default=None, primary_key=True)
         name: str
         type: str = Field(default="person")
 
@@ -26,13 +26,13 @@ def _make_person_engineer_classes():
 
     class Engineer(Person, table=True):
         __tablename__ = "rel_engineer"
-        id: Optional[int] = Field(
+        id: int | None = Field(
             default=None, primary_key=True, foreign_key="rel_person.id"
         )
-        primary_language: Optional[str] = None
+        primary_language: str | None = None
         # plain integer — no FK constraint, so inherit_condition stays unambiguous
-        reports_to_id: Optional[int] = None
-        reports_to: Optional[Person] = Relationship(
+        reports_to_id: int | None = None
+        reports_to: Person | None = Relationship(
             sa_relationship_kwargs={
                 "primaryjoin": "Engineer.reports_to_id == Person.id",
                 "foreign_keys": "[Engineer.reports_to_id]",
@@ -117,7 +117,7 @@ def test_jti_subclass_relationship_to_base_filter():
 def _make_engineer_self_ref_classes():
     class SPerson(SQLModel, table=True):
         __tablename__ = "rel_sperson"
-        id: Optional[int] = Field(default=None, primary_key=True)
+        id: int | None = Field(default=None, primary_key=True)
         name: str
         type: str = Field(default="person")
 
@@ -128,13 +128,11 @@ def _make_engineer_self_ref_classes():
 
     class SEngineer(SPerson, table=True):
         __tablename__ = "rel_sengineer"
-        id: Optional[int] = Field(
+        id: int | None = Field(
             default=None, primary_key=True, foreign_key="rel_sperson.id"
         )
-        primary_language: Optional[str] = None
-        reports_to_id: Optional[int] = Field(
-            default=None, foreign_key="rel_sengineer.id"
-        )
+        primary_language: str | None = None
+        reports_to_id: int | None = Field(default=None, foreign_key="rel_sengineer.id")
         reports_to: Optional["SEngineer"] = Relationship(
             sa_relationship_kwargs={
                 "primaryjoin": "SEngineer.reports_to_id == SEngineer.id",

--- a/tests/test_polymorphic/test_poly_relationships.py
+++ b/tests/test_polymorphic/test_poly_relationships.py
@@ -1,0 +1,192 @@
+"""
+Mirrors sqlalchemy/test/orm/inheritance/test_relationship.py ::
+    SelfReferentialTestJoinedToBase
+    SelfReferentialJ2JTest
+"""
+
+from typing import Optional
+
+from sqlalchemy.orm import aliased
+from sqlmodel import Field, Relationship, Session, SQLModel, create_engine, select
+
+
+# SelfReferentialTestJoinedToBase
+# Engineer has a relationship back to the Person base class.
+def _make_person_engineer_classes():
+    class Person(SQLModel, table=True):
+        __tablename__ = "rel_person"
+        id: Optional[int] = Field(default=None, primary_key=True)
+        name: str
+        type: str = Field(default="person")
+
+        __mapper_args__ = {
+            "polymorphic_on": "type",
+            "polymorphic_identity": "person",
+        }
+
+    class Engineer(Person, table=True):
+        __tablename__ = "rel_engineer"
+        id: Optional[int] = Field(
+            default=None, primary_key=True, foreign_key="rel_person.id"
+        )
+        primary_language: Optional[str] = None
+        # plain integer — no FK constraint, so inherit_condition stays unambiguous
+        reports_to_id: Optional[int] = None
+        reports_to: Optional[Person] = Relationship(
+            sa_relationship_kwargs={
+                "primaryjoin": "Engineer.reports_to_id == Person.id",
+                "foreign_keys": "[Engineer.reports_to_id]",
+            }
+        )
+
+        __mapper_args__ = {"polymorphic_identity": "engineer"}
+
+    return Person, Engineer
+
+
+def test_jti_subclass_relationship_to_base_persists():
+    # mirrors SelfReferentialTestJoinedToBase.test_has
+    Person, Engineer = _make_person_engineer_classes()
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as db:
+        p1 = Person(name="dogbert")
+        e1 = Engineer(name="dilbert", primary_language="java")
+        db.add_all([p1, e1])
+        db.flush()
+        e1.reports_to = p1
+        db.commit()
+        e1_id = e1.id
+
+    with Session(engine) as db:
+        e = db.get(Engineer, e1_id)
+        assert e.reports_to.name == "dogbert"
+
+
+def test_jti_subclass_relationship_to_base_fk():
+    # reports_to_id is set when the relationship is assigned
+    Person, Engineer = _make_person_engineer_classes()
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as db:
+        mgr = Person(name="pointy_hair")
+        eng = Engineer(name="wally", primary_language="c")
+        db.add_all([mgr, eng])
+        db.flush()
+        mgr_id = mgr.id
+
+        eng.reports_to = mgr
+        db.commit()
+        eng_id = eng.id
+
+    with Session(engine) as db:
+        eng = db.get(Engineer, eng_id)
+        assert eng.reports_to_id == mgr_id
+
+
+def test_jti_subclass_relationship_to_base_filter():
+    # mirrors SelfReferentialTestJoinedToBase.test_join
+    Person, Engineer = _make_person_engineer_classes()
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as db:
+        boss = Person(name="boss")
+        e1 = Engineer(name="alice", primary_language="python")
+        e2 = Engineer(name="bob", primary_language="java")
+        db.add_all([boss, e1, e2])
+        db.flush()
+        e1.reports_to = boss
+        db.commit()
+
+    with Session(engine) as db:
+        # alias Person to avoid ambiguity: rel_person is already joined for JTI
+        manager = aliased(Person)
+        results = db.exec(
+            select(Engineer)
+            .join(manager, Engineer.reports_to_id == manager.id)
+            .where(manager.name == "boss")
+        ).all()
+        assert len(results) == 1
+        assert results[0].name == "alice"
+
+
+# Engineer has a self-referential foreign key to the same subclass table.
+def _make_engineer_self_ref_classes():
+    class SPerson(SQLModel, table=True):
+        __tablename__ = "rel_sperson"
+        id: Optional[int] = Field(default=None, primary_key=True)
+        name: str
+        type: str = Field(default="person")
+
+        __mapper_args__ = {
+            "polymorphic_on": "type",
+            "polymorphic_identity": "person",
+        }
+
+    class SEngineer(SPerson, table=True):
+        __tablename__ = "rel_sengineer"
+        id: Optional[int] = Field(
+            default=None, primary_key=True, foreign_key="rel_sperson.id"
+        )
+        primary_language: Optional[str] = None
+        reports_to_id: Optional[int] = Field(
+            default=None, foreign_key="rel_sengineer.id"
+        )
+        reports_to: Optional["SEngineer"] = Relationship(
+            sa_relationship_kwargs={
+                "primaryjoin": "SEngineer.reports_to_id == SEngineer.id",
+                "foreign_keys": "[SEngineer.reports_to_id]",
+                "remote_side": "SEngineer.id",
+            }
+        )
+
+        __mapper_args__ = {"polymorphic_identity": "engineer"}
+
+    return SPerson, SEngineer
+
+
+def test_jti_subclass_self_referential_persists():
+    # mirrors SelfReferentialJ2JTest.test_has
+    SPerson, SEngineer = _make_engineer_self_ref_classes()
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as db:
+        lead = SEngineer(name="lead", primary_language="python")
+        junior = SEngineer(name="junior", primary_language="java")
+        db.add_all([lead, junior])
+        db.flush()
+        junior.reports_to = lead
+        db.commit()
+        junior_id = junior.id
+
+    with Session(engine) as db:
+        e = db.get(SEngineer, junior_id)
+        assert e.reports_to.name == "lead"
+        assert isinstance(e.reports_to, SEngineer)
+
+
+def test_jti_subclass_self_referential_chain():
+    # mirrors SelfReferentialJ2JTest.test_join — three-level reporting chain
+    SPerson, SEngineer = _make_engineer_self_ref_classes()
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as db:
+        vp = SEngineer(name="vp", primary_language="c")
+        mgr = SEngineer(name="mgr", primary_language="java")
+        ic = SEngineer(name="ic", primary_language="python")
+        db.add_all([vp, mgr, ic])
+        db.flush()
+        mgr.reports_to = vp
+        ic.reports_to = mgr
+        db.commit()
+        ic_id = ic.id
+
+    with Session(engine) as db:
+        e = db.get(SEngineer, ic_id)
+        assert e.reports_to.name == "mgr"
+        assert e.reports_to.reports_to.name == "vp"

--- a/tests/test_polymorphic/test_polymorphic_constructor.py
+++ b/tests/test_polymorphic/test_polymorphic_constructor.py
@@ -1,0 +1,93 @@
+from typing import Optional
+
+from sqlmodel import Field, Relationship, Session, SQLModel, create_engine
+
+
+def _make_dept_employee_classes():
+    """Department → Employee (base) → Manager (joined table inheritance subclass)."""
+
+    class Department(SQLModel, table=True):
+        __tablename__ = "department"
+        id: Optional[int] = Field(default=None, primary_key=True)
+        name: str
+        employees: list["Employee"] = Relationship(back_populates="department")
+
+    class Employee(SQLModel, table=True):
+        __tablename__ = "employee"
+        id: Optional[int] = Field(default=None, primary_key=True)
+        type: str = Field(default="employee")
+        name: str
+        department_id: Optional[int] = Field(
+            default=None, foreign_key="department.id"
+        )
+        department: Optional[Department] = Relationship(back_populates="employees")
+
+        __mapper_args__ = {
+            "polymorphic_on": "type",
+            "polymorphic_identity": "employee",
+        }
+
+    class Manager(Employee, table=True):
+        __tablename__ = "manager"
+        id: Optional[int] = Field(
+            default=None, primary_key=True, foreign_key="employee.id"
+        )
+        budget: Optional[float] = Field(default=None)
+
+        __mapper_args__ = {"polymorphic_identity": "manager"}
+
+    return Department, Employee, Manager
+
+
+def test_constructor_inherited_relationship_sets_fk():
+    """
+    Passing an inherited relationship as a constructor kwarg must propagate
+    the foreign key so the row is persisted with the correct value.
+    """
+    Department, Employee, Manager = _make_dept_employee_classes()
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as db:
+        eng = Department(name="Engineering")
+        db.add(eng)
+        db.commit()
+        db.refresh(eng)
+        dept_id = eng.id
+
+        m = Manager(name="Alice", budget=100_000.0, department=eng)
+        db.add(m)
+        db.commit()
+        m_id = m.id
+
+    with Session(engine) as db:
+        m = db.get(Manager, m_id)
+        assert m.department_id == dept_id
+        assert m.department.name == "Engineering"
+
+
+def test_constructor_inherited_relationship_back_populates():
+    """
+    The back-populated collection on the related model reflects joined table
+    inheritance subclass instances created via the constructor relationship kwarg.
+    """
+    Department, Employee, Manager = _make_dept_employee_classes()
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as db:
+        eng = Department(name="Engineering")
+        db.add(eng)
+        db.flush()
+        dept_id = eng.id
+
+        db.add(Manager(name="Alice", budget=80_000.0, department=eng))
+        db.add(Manager(name="Bob", budget=90_000.0, department=eng))
+        db.commit()
+
+    with Session(engine) as db:
+        dept = db.get(Department, dept_id)
+        employees = dept.employees
+        assert len(employees) == 2
+        assert all(isinstance(e, Manager) for e in employees)
+        assert {e.name for e in employees} == {"Alice", "Bob"}

--- a/tests/test_polymorphic/test_polymorphic_constructor.py
+++ b/tests/test_polymorphic/test_polymorphic_constructor.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from sqlmodel import Field, Relationship, Session, SQLModel, create_engine
 
 
@@ -8,19 +6,17 @@ def _make_dept_employee_classes():
 
     class Department(SQLModel, table=True):
         __tablename__ = "department"
-        id: Optional[int] = Field(default=None, primary_key=True)
+        id: int | None = Field(default=None, primary_key=True)
         name: str
         employees: list["Employee"] = Relationship(back_populates="department")
 
     class Employee(SQLModel, table=True):
         __tablename__ = "employee"
-        id: Optional[int] = Field(default=None, primary_key=True)
+        id: int | None = Field(default=None, primary_key=True)
         type: str = Field(default="employee")
         name: str
-        department_id: Optional[int] = Field(
-            default=None, foreign_key="department.id"
-        )
-        department: Optional[Department] = Relationship(back_populates="employees")
+        department_id: int | None = Field(default=None, foreign_key="department.id")
+        department: Department | None = Relationship(back_populates="employees")
 
         __mapper_args__ = {
             "polymorphic_on": "type",
@@ -29,10 +25,10 @@ def _make_dept_employee_classes():
 
     class Manager(Employee, table=True):
         __tablename__ = "manager"
-        id: Optional[int] = Field(
+        id: int | None = Field(
             default=None, primary_key=True, foreign_key="employee.id"
         )
-        budget: Optional[float] = Field(default=None)
+        budget: float | None = Field(default=None)
 
         __mapper_args__ = {"polymorphic_identity": "manager"}
 

--- a/tests/test_polymorphic/test_polymorphic_metaclass_helpers.py
+++ b/tests/test_polymorphic/test_polymorphic_metaclass_helpers.py
@@ -1,9 +1,10 @@
 from typing import Any, ClassVar, Optional, get_origin
 
-from sqlmodel import Field, SQLModel
+from sqlmodel import Field, Relationship, SQLModel
 from sqlmodel._compat import (
     _collect_inherited_namespace,
     _is_polymorphic_subclass,
+    _relationship_keys,
     _wrap_inherited_relationships_as_classvar,
 )
 
@@ -27,6 +28,31 @@ def test_collect_inherited_namespace_merges_base_fields():
     merged = _collect_inherited_namespace((_PolyBase,), {"__annotations__": {"extra": str}})
     assert "extra" in merged["__annotations__"]
     assert "id" in merged or "id" in merged["__annotations__"]
+
+
+def test_relationship_keys_table_model_uses_mapper():
+    # table model: keys come from the SQLAlchemy mapper (includes inherited relationships)
+    class RkOwner(SQLModel, table=True):
+        __tablename__ = "rk_owner"
+        id: Optional[int] = Field(default=None, primary_key=True)
+        items: list["RkItem"] = Relationship(back_populates="owner")
+
+    class RkItem(SQLModel, table=True):
+        __tablename__ = "rk_item"
+        id: Optional[int] = Field(default=None, primary_key=True)
+        owner_id: Optional[int] = Field(default=None, foreign_key="rk_owner.id")
+        owner: Optional[RkOwner] = Relationship(back_populates="items")
+
+    assert "owner" in list(_relationship_keys(RkItem()))
+
+
+def test_relationship_keys_non_table_model_uses_sqlmodel_relationships():
+    # non-table model: mapper is None, falls back to __sqlmodel_relationships__
+    class Plain(SQLModel):
+        name: str = ""
+
+    plain = Plain()
+    assert list(_relationship_keys(plain)) == list(plain.__sqlmodel_relationships__)
 
 
 def test_wrap_inherited_relationships_marks_classvar():

--- a/tests/test_polymorphic/test_polymorphic_metaclass_helpers.py
+++ b/tests/test_polymorphic/test_polymorphic_metaclass_helpers.py
@@ -1,4 +1,4 @@
-from typing import Any, ClassVar, Optional, get_origin
+from typing import Any, ClassVar, get_origin
 
 from sqlmodel import Field, Relationship, SQLModel
 from sqlmodel._compat import (
@@ -11,7 +11,7 @@ from sqlmodel._compat import (
 
 class _PolyBase(SQLModel, table=True):
     __tablename__ = "helpers_poly_base"
-    id: Optional[int] = Field(default=None, primary_key=True)
+    id: int | None = Field(default=None, primary_key=True)
     kind: str = Field(default="base")
     __mapper_args__ = {"polymorphic_on": "kind", "polymorphic_identity": "base"}
 
@@ -25,7 +25,9 @@ def test_is_polymorphic_subclass_false_with_plain_base():
 
 
 def test_collect_inherited_namespace_merges_base_fields():
-    merged = _collect_inherited_namespace((_PolyBase,), {"__annotations__": {"extra": str}})
+    merged = _collect_inherited_namespace(
+        (_PolyBase,), {"__annotations__": {"extra": str}}
+    )
     assert "extra" in merged["__annotations__"]
     assert "id" in merged or "id" in merged["__annotations__"]
 
@@ -34,14 +36,14 @@ def test_relationship_keys_table_model_uses_mapper():
     # table model: keys come from the SQLAlchemy mapper (includes inherited relationships)
     class RkOwner(SQLModel, table=True):
         __tablename__ = "rk_owner"
-        id: Optional[int] = Field(default=None, primary_key=True)
+        id: int | None = Field(default=None, primary_key=True)
         items: list["RkItem"] = Relationship(back_populates="owner")
 
     class RkItem(SQLModel, table=True):
         __tablename__ = "rk_item"
-        id: Optional[int] = Field(default=None, primary_key=True)
-        owner_id: Optional[int] = Field(default=None, foreign_key="rk_owner.id")
-        owner: Optional[RkOwner] = Relationship(back_populates="items")
+        id: int | None = Field(default=None, primary_key=True)
+        owner_id: int | None = Field(default=None, foreign_key="rk_owner.id")
+        owner: RkOwner | None = Relationship(back_populates="items")
 
     assert "owner" in list(_relationship_keys(RkItem()))
 
@@ -60,7 +62,9 @@ def test_wrap_inherited_relationships_marks_classvar():
         __sqlmodel_relationships__ = {"owner": None}
 
     dict_used: dict[str, Any] = {"__annotations__": {}}
-    _wrap_inherited_relationships_as_classvar(FakeBase, {"owner": Optional[Any]}, dict_used)
+    _wrap_inherited_relationships_as_classvar(
+        FakeBase, {"owner": Any | None}, dict_used
+    )
     assert get_origin(dict_used["__annotations__"]["owner"]) is ClassVar
 
     dict_used: dict[str, Any] = {"__annotations__": {}}

--- a/tests/test_polymorphic/test_polymorphic_metaclass_helpers.py
+++ b/tests/test_polymorphic/test_polymorphic_metaclass_helpers.py
@@ -1,0 +1,42 @@
+from typing import Any, ClassVar, Optional, get_origin
+
+from sqlmodel import Field, SQLModel
+from sqlmodel._compat import (
+    _collect_inherited_namespace,
+    _is_polymorphic_subclass,
+    _wrap_inherited_relationships_as_classvar,
+)
+
+
+class _PolyBase(SQLModel, table=True):
+    __tablename__ = "helpers_poly_base"
+    id: Optional[int] = Field(default=None, primary_key=True)
+    kind: str = Field(default="base")
+    __mapper_args__ = {"polymorphic_on": "kind", "polymorphic_identity": "base"}
+
+
+def test_is_polymorphic_subclass_true_with_table_base():
+    assert _is_polymorphic_subclass((_PolyBase,)) is True
+
+
+def test_is_polymorphic_subclass_false_with_plain_base():
+    assert _is_polymorphic_subclass((object,)) is False
+
+
+def test_collect_inherited_namespace_merges_base_fields():
+    merged = _collect_inherited_namespace((_PolyBase,), {"__annotations__": {"extra": str}})
+    assert "extra" in merged["__annotations__"]
+    assert "id" in merged or "id" in merged["__annotations__"]
+
+
+def test_wrap_inherited_relationships_marks_classvar():
+    class FakeBase:
+        __sqlmodel_relationships__ = {"owner": None}
+
+    dict_used: dict[str, Any] = {"__annotations__": {}}
+    _wrap_inherited_relationships_as_classvar(FakeBase, {"owner": Optional[Any]}, dict_used)
+    assert get_origin(dict_used["__annotations__"]["owner"]) is ClassVar
+
+    dict_used: dict[str, Any] = {"__annotations__": {}}
+    _wrap_inherited_relationships_as_classvar(object, {}, dict_used)
+    assert dict_used["__annotations__"] == {}

--- a/tests/test_polymorphic/test_polymorphic_typedecorator.py
+++ b/tests/test_polymorphic/test_polymorphic_typedecorator.py
@@ -1,9 +1,18 @@
 import json
 import typing as t
-from typing import Optional
 
 from pydantic import BaseModel, TypeAdapter
-from sqlmodel import JSON, Column, Field, Session, SQLModel, TypeDecorator, create_engine, select
+from sqlmodel import (
+    JSON,
+    Column,
+    Field,
+    Session,
+    SQLModel,
+    TypeDecorator,
+    create_engine,
+    select,
+)
+
 
 # See https://github.com/fastapi/sqlmodel/pull/1226#issuecomment-2568867964
 def _make_classes():
@@ -23,6 +32,7 @@ def _make_classes():
                     if isinstance(value, str):
                         value = json.loads(value)
                     return TypeAdapter(pydantic_type).validate_python(value)
+
                 return process
 
             def compare_values(self, x: t.Any, y: t.Any) -> bool:
@@ -35,7 +45,7 @@ def _make_classes():
 
     class ComplexModel(SQLModel, table=True):
         __tablename__ = "complexmodel"
-        id: Optional[int] = Field(default=None, primary_key=True)
+        id: int | None = Field(default=None, primary_key=True)
         my_model: t.Annotated[
             MyModel | None,
             Field(sa_column=Column(pydantic_column_type(MyModel)())),
@@ -43,9 +53,12 @@ def _make_classes():
 
     class Hero(SQLModel, table=True):
         __tablename__ = "hero"
-        id: Optional[int] = Field(default=None, primary_key=True)
+        id: int | None = Field(default=None, primary_key=True)
         hero_type: str = Field(default="hero")
-        __mapper_args__ = {"polymorphic_on": "hero_type", "polymorphic_identity": "hero"}
+        __mapper_args__ = {
+            "polymorphic_on": "hero_type",
+            "polymorphic_identity": "hero",
+        }
 
     class DarkHero(Hero):
         __mapper_args__ = {"polymorphic_identity": "dark"}

--- a/tests/test_polymorphic/test_polymorphic_typedecorator.py
+++ b/tests/test_polymorphic/test_polymorphic_typedecorator.py
@@ -1,0 +1,73 @@
+import json
+import typing as t
+from typing import Optional
+
+from pydantic import BaseModel, TypeAdapter
+from sqlmodel import JSON, Column, Field, Session, SQLModel, TypeDecorator, create_engine, select
+
+# See https://github.com/fastapi/sqlmodel/pull/1226#issuecomment-2568867964
+def _make_classes():
+    def pydantic_column_type(pydantic_type: type) -> type:
+        class PydanticJSONType(TypeDecorator):
+            impl = JSON()
+            cache_ok = False
+
+            def __init__(self, json_encoder: t.Any = json):
+                self.json_encoder = json_encoder
+                super().__init__()
+
+            def result_processor(self, dialect: t.Any, coltype: t.Any) -> t.Any:
+                def process(value: t.Any) -> t.Any:
+                    if value is None:
+                        return None
+                    if isinstance(value, str):
+                        value = json.loads(value)
+                    return TypeAdapter(pydantic_type).validate_python(value)
+                return process
+
+            def compare_values(self, x: t.Any, y: t.Any) -> bool:
+                return x == y
+
+        return PydanticJSONType
+
+    class MyModel(BaseModel):
+        name: str | None = None
+
+    class ComplexModel(SQLModel, table=True):
+        __tablename__ = "complexmodel"
+        id: Optional[int] = Field(default=None, primary_key=True)
+        my_model: t.Annotated[
+            MyModel | None,
+            Field(sa_column=Column(pydantic_column_type(MyModel)())),
+        ] = None
+
+    class Hero(SQLModel, table=True):
+        __tablename__ = "hero"
+        id: Optional[int] = Field(default=None, primary_key=True)
+        hero_type: str = Field(default="hero")
+        __mapper_args__ = {"polymorphic_on": "hero_type", "polymorphic_identity": "hero"}
+
+    class DarkHero(Hero):
+        __mapper_args__ = {"polymorphic_identity": "dark"}
+
+    return ComplexModel, Hero, DarkHero
+
+
+def test_polymorphic_coexists_with_custom_type_decorator():
+    """
+    Defining a polymorphic subclass alongside a model with a custom
+    TypeDecorator whose default holds a non-picklable object (e.g. the json
+    module) should work.
+    """
+    ComplexModel, Hero, DarkHero = _make_classes()
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as db:
+        db.add(Hero())
+        db.add(DarkHero())
+        db.commit()
+        result = db.exec(select(DarkHero)).all()
+
+    assert len(result) == 1
+    assert isinstance(result[0], DarkHero)

--- a/tests/test_polymorphic/test_schema.py
+++ b/tests/test_polymorphic/test_schema.py
@@ -1,0 +1,205 @@
+# Verify that polymorphic inheritance produces the correct table structure at the database level.
+
+from typing import Optional
+
+from sqlalchemy import text
+from sqlmodel import Field, Session, SQLModel, create_engine
+
+
+# Joined inheritance table: each subclass gets its own table. The base table holds shared columns and the subclass table holds its own columns.
+def _make_jti_classes():
+    class Animal(SQLModel, table=True):
+        __tablename__ = "schema_animal"
+        id: Optional[int] = Field(default=None, primary_key=True)
+        type: str = Field(default="animal")
+        name: str
+
+        __mapper_args__ = {
+            "polymorphic_on": "type",
+            "polymorphic_identity": "animal",
+        }
+
+    class Dog(Animal, table=True):
+        __tablename__ = "schema_dog"
+        id: Optional[int] = Field(
+            default=None, primary_key=True, foreign_key="schema_animal.id"
+        )
+        breed: Optional[str] = None
+
+        __mapper_args__ = {"polymorphic_identity": "dog"}
+
+    class Bulldog(Dog, table=True):
+        __tablename__ = "schema_bulldog"
+        id: Optional[int] = Field(
+            default=None, primary_key=True, foreign_key="schema_dog.id"
+        )
+        wrinkle_count: Optional[int] = None
+
+        __mapper_args__ = {"polymorphic_identity": "bulldog"}
+
+    return Animal, Dog, Bulldog
+
+
+def test_jti_data_split_across_tables():
+    Animal, Dog, Bulldog = _make_jti_classes()
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as db:
+        d = Dog(name="Rex", breed="Labrador")
+        db.add(d)
+        db.commit()
+        dog_id = d.id
+
+    with engine.connect() as conn:
+        animal_row = conn.execute(
+            text("SELECT name, type FROM schema_animal WHERE id = :id"),
+            {"id": dog_id},
+        ).fetchone()
+        assert animal_row is not None
+        assert animal_row[0] == "Rex"
+        assert animal_row[1] == "dog"
+
+        dog_row = conn.execute(
+            text("SELECT breed FROM schema_dog WHERE id = :id"),
+            {"id": dog_id},
+        ).fetchone()
+        assert dog_row is not None
+        assert dog_row[0] == "Labrador"
+
+        # Confirm no columns leaked across tables.
+        animal_cols = {
+            r[1]
+            for r in conn.execute(text("PRAGMA table_info(schema_animal)")).fetchall()
+        }
+        dog_cols = {
+            r[1]
+            for r in conn.execute(text("PRAGMA table_info(schema_dog)")).fetchall()
+        }
+        assert animal_cols == {"id", "type", "name"}
+        assert dog_cols == {"id", "breed"}
+
+
+def test_jti_three_level_data_split_across_tables():
+    Animal, Dog, Bulldog = _make_jti_classes()
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as db:
+        b = Bulldog(name="Wrinkles", breed="English Bulldog", wrinkle_count=42)
+        db.add(b)
+        db.commit()
+        bulldog_id = b.id
+
+    with engine.connect() as conn:
+        animal_row = conn.execute(
+            text("SELECT name, type FROM schema_animal WHERE id = :id"),
+            {"id": bulldog_id},
+        ).fetchone()
+        assert animal_row is not None
+        assert animal_row[0] == "Wrinkles"
+        assert animal_row[1] == "bulldog"
+
+        dog_row = conn.execute(
+            text("SELECT breed FROM schema_dog WHERE id = :id"),
+            {"id": bulldog_id},
+        ).fetchone()
+        assert dog_row is not None
+        assert dog_row[0] == "English Bulldog"
+
+        bulldog_row = conn.execute(
+            text("SELECT wrinkle_count FROM schema_bulldog WHERE id = :id"),
+            {"id": bulldog_id},
+        ).fetchone()
+        assert bulldog_row is not None
+        assert bulldog_row[0] == 42
+
+        animal_cols = {
+            r[1]
+            for r in conn.execute(text("PRAGMA table_info(schema_animal)")).fetchall()
+        }
+        dog_cols = {
+            r[1]
+            for r in conn.execute(text("PRAGMA table_info(schema_dog)")).fetchall()
+        }
+        bulldog_cols = {
+            r[1]
+            for r in conn.execute(text("PRAGMA table_info(schema_bulldog)")).fetchall()
+        }
+        assert animal_cols == {"id", "type", "name"}
+        assert dog_cols == {"id", "breed"}
+        assert bulldog_cols == {"id", "wrinkle_count"}
+
+
+# Single inheritance table: all subclasses share one table. The type column identifies which subclass each row belongs to.
+def _make_sti_classes():
+    class Vehicle(SQLModel, table=True):
+        __tablename__ = "schema_vehicle"
+        id: Optional[int] = Field(default=None, primary_key=True)
+        type: str = Field(default="vehicle")
+        name: str
+
+        __mapper_args__ = {
+            "polymorphic_on": "type",
+            "polymorphic_identity": "vehicle",
+        }
+
+    class Car(Vehicle):
+        num_doors: Optional[int] = None
+        __mapper_args__ = {"polymorphic_identity": "car"}
+
+    class Truck(Vehicle):
+        payload_tons: Optional[int] = None
+        __mapper_args__ = {"polymorphic_identity": "truck"}
+
+    return Vehicle, Car, Truck
+
+
+def test_sti_data_in_single_table():
+    Vehicle, Car, Truck = _make_sti_classes()
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as db:
+        c = Car(name="Tesla", num_doors=4)
+        t = Truck(name="Ford F-150", payload_tons=1)
+        db.add(c)
+        db.add(t)
+        db.commit()
+        car_id = c.id
+        truck_id = t.id
+
+    with engine.connect() as conn:
+        # Each row has its own feature column set and the other subclass column is null.
+        car_row = conn.execute(
+            text("SELECT name, type, num_doors, payload_tons FROM schema_vehicle WHERE id = :id"),
+            {"id": car_id},
+        ).fetchone()
+        assert car_row is not None
+        assert car_row[0] == "Tesla"
+        assert car_row[1] == "car"
+        assert car_row[2] == 4
+        assert car_row[3] is None
+
+        truck_row = conn.execute(
+            text("SELECT name, type, num_doors, payload_tons FROM schema_vehicle WHERE id = :id"),
+            {"id": truck_id},
+        ).fetchone()
+        assert truck_row is not None
+        assert truck_row[0] == "Ford F-150"
+        assert truck_row[1] == "truck"
+        assert truck_row[2] is None
+        assert truck_row[3] == 1
+
+        # Only one table should exist; subclasses must not create their own.
+        tables = conn.execute(
+            text("SELECT name FROM sqlite_master WHERE type='table'")
+        ).fetchall()
+        table_names = {r[0] for r in tables}
+        assert table_names == {"schema_vehicle"}
+
+        vehicle_cols = {
+            r[1]
+            for r in conn.execute(text("PRAGMA table_info(schema_vehicle)")).fetchall()
+        }
+        assert vehicle_cols == {"id", "type", "name", "num_doors", "payload_tons"}

--- a/tests/test_polymorphic/test_schema.py
+++ b/tests/test_polymorphic/test_schema.py
@@ -1,6 +1,5 @@
 # Verify that polymorphic inheritance produces the correct table structure at the database level.
 
-from typing import Optional
 
 from sqlalchemy import text
 from sqlmodel import Field, Session, SQLModel, create_engine
@@ -10,7 +9,7 @@ from sqlmodel import Field, Session, SQLModel, create_engine
 def _make_jti_classes():
     class Animal(SQLModel, table=True):
         __tablename__ = "schema_animal"
-        id: Optional[int] = Field(default=None, primary_key=True)
+        id: int | None = Field(default=None, primary_key=True)
         type: str = Field(default="animal")
         name: str
 
@@ -21,19 +20,19 @@ def _make_jti_classes():
 
     class Dog(Animal, table=True):
         __tablename__ = "schema_dog"
-        id: Optional[int] = Field(
+        id: int | None = Field(
             default=None, primary_key=True, foreign_key="schema_animal.id"
         )
-        breed: Optional[str] = None
+        breed: str | None = None
 
         __mapper_args__ = {"polymorphic_identity": "dog"}
 
     class Bulldog(Dog, table=True):
         __tablename__ = "schema_bulldog"
-        id: Optional[int] = Field(
+        id: int | None = Field(
             default=None, primary_key=True, foreign_key="schema_dog.id"
         )
-        wrinkle_count: Optional[int] = None
+        wrinkle_count: int | None = None
 
         __mapper_args__ = {"polymorphic_identity": "bulldog"}
 
@@ -73,8 +72,7 @@ def test_jti_data_split_across_tables():
             for r in conn.execute(text("PRAGMA table_info(schema_animal)")).fetchall()
         }
         dog_cols = {
-            r[1]
-            for r in conn.execute(text("PRAGMA table_info(schema_dog)")).fetchall()
+            r[1] for r in conn.execute(text("PRAGMA table_info(schema_dog)")).fetchall()
         }
         assert animal_cols == {"id", "type", "name"}
         assert dog_cols == {"id", "breed"}
@@ -119,8 +117,7 @@ def test_jti_three_level_data_split_across_tables():
             for r in conn.execute(text("PRAGMA table_info(schema_animal)")).fetchall()
         }
         dog_cols = {
-            r[1]
-            for r in conn.execute(text("PRAGMA table_info(schema_dog)")).fetchall()
+            r[1] for r in conn.execute(text("PRAGMA table_info(schema_dog)")).fetchall()
         }
         bulldog_cols = {
             r[1]
@@ -135,7 +132,7 @@ def test_jti_three_level_data_split_across_tables():
 def _make_sti_classes():
     class Vehicle(SQLModel, table=True):
         __tablename__ = "schema_vehicle"
-        id: Optional[int] = Field(default=None, primary_key=True)
+        id: int | None = Field(default=None, primary_key=True)
         type: str = Field(default="vehicle")
         name: str
 
@@ -145,11 +142,11 @@ def _make_sti_classes():
         }
 
     class Car(Vehicle):
-        num_doors: Optional[int] = None
+        num_doors: int | None = None
         __mapper_args__ = {"polymorphic_identity": "car"}
 
     class Truck(Vehicle):
-        payload_tons: Optional[int] = None
+        payload_tons: int | None = None
         __mapper_args__ = {"polymorphic_identity": "truck"}
 
     return Vehicle, Car, Truck
@@ -172,7 +169,9 @@ def test_sti_data_in_single_table():
     with engine.connect() as conn:
         # Each row has its own feature column set and the other subclass column is null.
         car_row = conn.execute(
-            text("SELECT name, type, num_doors, payload_tons FROM schema_vehicle WHERE id = :id"),
+            text(
+                "SELECT name, type, num_doors, payload_tons FROM schema_vehicle WHERE id = :id"
+            ),
             {"id": car_id},
         ).fetchone()
         assert car_row is not None
@@ -182,7 +181,9 @@ def test_sti_data_in_single_table():
         assert car_row[3] is None
 
         truck_row = conn.execute(
-            text("SELECT name, type, num_doors, payload_tons FROM schema_vehicle WHERE id = :id"),
+            text(
+                "SELECT name, type, num_doors, payload_tons FROM schema_vehicle WHERE id = :id"
+            ),
             {"id": truck_id},
         ).fetchone()
         assert truck_row is not None

--- a/tests/test_polymorphic/test_single.py
+++ b/tests/test_polymorphic/test_single.py
@@ -1,7 +1,5 @@
 """Mirrors sqlalchemy/test/orm/inheritance/test_single.py :: SingleInheritanceTest, AbstractPolymorphicTest"""
 
-from typing import Optional
-
 from sqlalchemy import true
 from sqlalchemy.orm import aliased, mapped_column
 from sqlmodel import Field, Session, SQLModel, create_engine, select
@@ -10,12 +8,12 @@ from sqlmodel import Field, Session, SQLModel, create_engine, select
 def _employee_classes():
     class Employee(SQLModel, table=True):
         __tablename__ = "employees"
-        employee_id: Optional[int] = Field(default=None, primary_key=True)
+        employee_id: int | None = Field(default=None, primary_key=True)
         name: str
-        manager_data: Optional[str] = Field(
+        manager_data: str | None = Field(
             default=None, sa_column=mapped_column(nullable=True)
         )
-        engineer_info: Optional[str] = Field(
+        engineer_info: str | None = Field(
             default=None, sa_column=mapped_column(nullable=True)
         )
         type: str = Field(default="employee")
@@ -138,13 +136,13 @@ def test_abstract_intermediate():
     # mirrors AbstractPolymorphicTest.test_select_against_abstract
     class Employee(SQLModel, table=True):
         __tablename__ = "emp_abstract"
-        id: Optional[int] = Field(default=None, primary_key=True)
+        id: int | None = Field(default=None, primary_key=True)
         type: str = Field(default="employee")
         name: str
-        mgr_data: Optional[str] = Field(
+        mgr_data: str | None = Field(
             default=None, sa_column=mapped_column(nullable=True)
         )
-        tech_data: Optional[str] = Field(
+        tech_data: str | None = Field(
             default=None, sa_column=mapped_column(nullable=True)
         )
 

--- a/tests/test_polymorphic/test_single.py
+++ b/tests/test_polymorphic/test_single.py
@@ -1,0 +1,182 @@
+"""Mirrors sqlalchemy/test/orm/inheritance/test_single.py :: SingleInheritanceTest, AbstractPolymorphicTest"""
+
+from typing import Optional
+
+from sqlalchemy import true
+from sqlalchemy.orm import aliased, mapped_column
+from sqlmodel import Field, Session, SQLModel, create_engine, select
+
+
+def _employee_classes():
+    class Employee(SQLModel, table=True):
+        __tablename__ = "employees"
+        employee_id: Optional[int] = Field(default=None, primary_key=True)
+        name: str
+        manager_data: Optional[str] = Field(
+            default=None, sa_column=mapped_column(nullable=True)
+        )
+        engineer_info: Optional[str] = Field(
+            default=None, sa_column=mapped_column(nullable=True)
+        )
+        type: str = Field(default="employee")
+
+        __mapper_args__ = {
+            "polymorphic_on": "type",
+            "polymorphic_identity": "employee",
+        }
+
+    class Manager(Employee):
+        __mapper_args__ = {"polymorphic_identity": "manager"}
+
+    class Engineer(Employee):
+        __mapper_args__ = {"polymorphic_identity": "engineer"}
+
+    class JuniorEngineer(Engineer):
+        __mapper_args__ = {"polymorphic_identity": "juniorengineer"}
+
+    return Employee, Manager, Engineer, JuniorEngineer
+
+
+def _seed_employees(engine, Manager, Engineer, JuniorEngineer):
+    with Session(engine) as db:
+        db.add(Manager(name="Tom", manager_data="knows how to manage things"))
+        db.add(Engineer(name="Kurt", engineer_info="knows how to hack"))
+        db.add(JuniorEngineer(name="Ed", engineer_info="oh that ed"))
+        db.commit()
+
+
+# ---------------------------------------------------------------------------
+# SingleInheritanceTest
+# ---------------------------------------------------------------------------
+
+
+def test_single_inheritance():
+    # mirrors SingleInheritanceTest.test_single_inheritance
+    Employee, Manager, Engineer, JuniorEngineer = _employee_classes()
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+    _seed_employees(engine, Manager, Engineer, JuniorEngineer)
+
+    with Session(engine) as db:
+        employees = db.exec(select(Employee)).all()
+        engineers = db.exec(select(Engineer)).all()
+        managers = db.exec(select(Manager)).all()
+        juniors = db.exec(select(JuniorEngineer)).all()
+
+        db.expire(managers[0], ["manager_data"])
+        assert managers[0].manager_data == "knows how to manage things"
+
+    assert len(employees) == 3
+    assert len(engineers) == 2  # Engineer + JuniorEngineer
+    assert len(managers) == 1
+    assert len(juniors) == 1
+    assert {type(e) for e in employees} == {Manager, Engineer, JuniorEngineer}
+    assert all(isinstance(e, Engineer) for e in engineers)
+
+
+def test_column_qualification():
+    # mirrors SingleInheritanceTest.test_column_qualification
+    Employee, Manager, Engineer, JuniorEngineer = _employee_classes()
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+    _seed_employees(engine, Manager, Engineer, JuniorEngineer)
+
+    with Session(engine) as db:
+        all_ids = db.scalars(select(Employee.employee_id)).all()
+        eng_ids = db.scalars(select(Engineer.employee_id)).all()
+        mgr_ids = db.scalars(select(Manager.employee_id)).all()
+        jun_ids = db.scalars(select(JuniorEngineer.employee_id)).all()
+
+    assert len(all_ids) == 3
+    assert len(eng_ids) == 2
+    assert len(mgr_ids) == 1
+    assert len(jun_ids) == 1
+    assert set(jun_ids) < set(eng_ids) < set(all_ids)
+
+
+def test_multi_qualification():
+    # mirrors SingleInheritanceTest.test_multi_qualification
+    Employee, Manager, Engineer, JuniorEngineer = _employee_classes()
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+    _seed_employees(engine, Manager, Engineer, JuniorEngineer)
+
+    with Session(engine) as db:
+        ealias = aliased(Engineer)
+        rows = db.execute(select(Manager, ealias).join(ealias, true())).all()
+
+    assert len(rows) == 2
+    assert all(isinstance(r[0], Manager) for r in rows)
+    assert all(isinstance(r[1], Engineer) for r in rows)
+
+
+def test_type_filtering():
+    # mirrors SingleInheritanceTest.test_type_filtering / test_type_joins
+    Employee, Manager, Engineer, JuniorEngineer = _employee_classes()
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+    _seed_employees(engine, Manager, Engineer, JuniorEngineer)
+
+    with Session(engine) as db:
+        engineers = db.exec(select(Engineer)).all()
+        juniors = db.exec(select(JuniorEngineer)).all()
+        managers = db.exec(select(Manager)).all()
+
+    assert len(engineers) == 2
+    assert len(juniors) == 1
+    assert len(managers) == 1
+    assert any(type(e) is JuniorEngineer for e in engineers)
+    assert not any(isinstance(e, Manager) for e in engineers)
+
+
+# ---------------------------------------------------------------------------
+# AbstractPolymorphicTest
+# ---------------------------------------------------------------------------
+
+
+def test_abstract_intermediate():
+    # mirrors AbstractPolymorphicTest.test_select_against_abstract
+    class Employee(SQLModel, table=True):
+        __tablename__ = "emp_abstract"
+        id: Optional[int] = Field(default=None, primary_key=True)
+        type: str = Field(default="employee")
+        name: str
+        mgr_data: Optional[str] = Field(
+            default=None, sa_column=mapped_column(nullable=True)
+        )
+        tech_data: Optional[str] = Field(
+            default=None, sa_column=mapped_column(nullable=True)
+        )
+
+        __mapper_args__ = {
+            "polymorphic_on": "type",
+            "polymorphic_identity": "employee",
+        }
+
+    class Executive(Employee):
+        __mapper_args__ = {"polymorphic_abstract": True}
+
+    class Technologist(Employee):
+        __mapper_args__ = {"polymorphic_abstract": True}
+
+    class Manager(Executive):
+        __mapper_args__ = {"polymorphic_identity": "manager"}
+
+    class Engineer(Technologist):
+        __mapper_args__ = {"polymorphic_identity": "engineer"}
+
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as db:
+        db.add(Manager(name="Alice", mgr_data="MBA"))
+        db.add(Engineer(name="Bob", tech_data="Python"))
+        db.commit()
+
+        executives = db.exec(select(Executive)).all()
+        technologists = db.exec(select(Technologist)).all()
+        all_emps = db.exec(select(Employee)).all()
+
+    assert len(executives) == 1 and isinstance(executives[0], Manager)
+    assert len(technologists) == 1 and isinstance(technologists[0], Engineer)
+    assert len(all_emps) == 2


### PR DESCRIPTION
This PR builds on top of #1226 and completes support for SQLAlchemy single-table and joined-table polymorphic inheritance in SQLModel.

#1226 had some problems:
- inherited relationships passed as constructor kwargs were silently dropped
- assigning inherited relationships doesn't work
- merge conflicts

We fix these issues in this PR and add a more complete test suite.

## Commit structure

This PR is quite large (mainly due to tests), so the commits are split to make review easier.

### 1. Add metaclass support for SQLAlchemy polymorphic models

Adds support for both joined-table and single-table inheritance.

This commit:

- merges base-class fields into the subclass namespace
- auto-sets `__tablename__`
- skips already-instrumented attributes
- sets the polymorphic discriminator to `polymorphic_identity` on `__init__`

### 2. Fix inherited relationship resolution in polymorphic subclasses

`sqlmodel_table_construct` and `sqlmodel_validate` previously iterated only over `__sqlmodel_relationships__`, which missed relationships inherited from polymorphic base classes.

This commit replaces that logic with `_relationship_keys()`, which falls back to the SQLAlchemy mapper when available.

It also fixes `SQLModel.__setattr__`, which  now detects mapper-owned relationships with  `_is_sqlmodel_relationship()` and lets SQLAlchemy handle the assignment instead of forwarding the inherited relationship assignments to Pydantic.

### 3. Add polymorphic inheritance test suite

Adds a large test suite under `tests/test_polymorphic/`.

Most tests are ported from SQLAlchemy's own inheritance test suite, `test/orm/inheritance/`, and adapted to SQLModel's API.

The suite also covers issues raised in #1226 comments:

- https://github.com/fastapi/sqlmodel/pull/1226#issuecomment-2568867964  
  Custom `TypeDecorator` + polymorphic model pickle error  
  Covered by `test_polymorphic_typedecorator.py`

- https://github.com/fastapi/sqlmodel/pull/1226#issuecomment-3049507957  
  Self-referential relationship assignment on polymorphic subclasses  
  Covered by `test_poly_linked_list.py`

- https://github.com/fastapi/sqlmodel/pull/1226#issuecomment-3665530152  
  Relationships with polymorphic subclasses  
  Covered by `test_polymorphic_constructor.py`, and `test_manytomany.py`