### PR TITLE
🐛 Forward `by_alias` and `by_name` to `model_validate`

### DIFF
--- a/sqlmodel/_compat.py
+++ b/sqlmodel/_compat.py
@@ -280,6 +280,8 @@ def sqlmodel_validate(
     strict: bool | None = None,
     from_attributes: bool | None = None,
     context: dict[str, Any] | None = None,
+    by_alias: bool | None = None,
+    by_name: bool | None = None,
     update: dict[str, Any] | None = None,
 ) -> _TSQLModel:
     if not is_table_model_class(cls):
@@ -303,6 +305,8 @@ def sqlmodel_validate(
         strict=strict,
         from_attributes=from_attributes,
         context=context,
+        by_alias=by_alias,
+        by_name=by_name,
         self_instance=new_obj,
     )
     # Capture fields set to restore it later

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -876,6 +876,8 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
         strict: bool | None = None,
         from_attributes: bool | None = None,
         context: builtins.dict[str, Any] | None = None,
+        by_alias: bool | None = None,
+        by_name: bool | None = None,
         update: builtins.dict[str, Any] | None = None,
     ) -> _TSQLModel:
         return sqlmodel_validate(
@@ -884,6 +886,8 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
             strict=strict,
             from_attributes=from_attributes,
             context=context,
+            by_alias=by_alias,
+            by_name=by_name,
             update=update,
         )
 

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -179,3 +179,26 @@ def test_alias_generator_with_explicit_alias_prefers_field_alias_sqlmodel_v2():
     assert m.f == "ok"
     data = m.model_dump(by_alias=True)
     assert "custom" in data and "gen_f" not in data
+
+
+@pytest.mark.parametrize("model", [PydanticUser, SQLModelUser])
+def test_model_validate_by_name(
+    model: type[PydanticUser] | type[SQLModelUser],
+):
+    # By default, a field with an alias can't be populated by its name
+    with pytest.raises(ValidationError):
+        model.model_validate({"full_name": "Greg"})
+    # With by_name=True, the field name is accepted
+    user = model.model_validate({"full_name": "Greg"}, by_name=True)
+    assert user.full_name == "Greg"
+
+
+@pytest.mark.parametrize("model", [PydanticUser, SQLModelUser])
+def test_model_validate_by_alias_and_by_name(
+    model: type[PydanticUser] | type[SQLModelUser],
+):
+    # With both enabled, either the alias or the field name is accepted
+    by_alias = model.model_validate({"fullName": "Helen"}, by_alias=True, by_name=True)
+    assert by_alias.full_name == "Helen"
+    by_name = model.model_validate({"full_name": "Helen"}, by_alias=True, by_name=True)
+    assert by_name.full_name == "Helen"


### PR DESCRIPTION
## Description

SQLModel overrides `model_validate`, but the override does not accept or forward the `by_alias` and `by_name` arguments that Pydantic's `model_validate` supports.

SQLModel requires `pydantic>=2.11`, and both `by_alias` and `by_name` have been part of `model_validate` since Pydantic 2.11, so they are always available. Despite that, calling them on a SQLModel fails:

```python
from sqlmodel import SQLModel, Field

class Hero(SQLModel):
    name: str = Field(alias="heroName")

Hero.model_validate({"heroName": "Deadpond"}, by_alias=True)
# TypeError: SQLModel.model_validate() got an unexpected keyword argument 'by_alias'

Hero.model_validate({"name": "Deadpond"}, by_name=True)
# TypeError: SQLModel.model_validate() got an unexpected keyword argument 'by_name'
```

The plain Pydantic equivalent works, so this is a gap in SQLModel's override. It forces users with aliased fields to drop down to `__pydantic_validator__` or restructure their input.

This is also reported in #1824.

## Fix

Add `by_alias` and `by_name` to the `model_validate` override and to the internal `sqlmodel_validate` helper, forwarding them to `validate_python`. This mirrors how the other validation arguments (`strict`, `from_attributes`, `context`) are already handled, and keeps `model_validate` consistent with Pydantic.

No version gating is needed since the supported Pydantic floor (2.11) already includes both parameters.

## Tests

Added parametrized tests in `tests/test_aliases.py` that run the same assertions against a plain Pydantic model and the equivalent SQLModel, covering `by_name=True` and the `by_alias=True, by_name=True` combination. They fail on `main` with the `TypeError` above and pass with this change.