### PR TITLE
✨ Add Engine class re-export from SQLAlchemy

### DIFF
--- a/sqlmodel/__init__.py
+++ b/sqlmodel/__init__.py
@@ -1,6 +1,7 @@
 __version__ = "0.0.38"
 
 # Re-export from SQLAlchemy
+from sqlalchemy.engine import Engine as Engine
 from sqlalchemy.engine import create_engine as create_engine
 from sqlalchemy.engine import create_mock_engine as create_mock_engine
 from sqlalchemy.engine import engine_from_config as engine_from_config


### PR DESCRIPTION
## Pull Request

## Description

This PR re-exports SQLAlchemy's `Engine` class from the top-level `sqlmodel`
namespace, alongside the already-exported `create_engine`, `create_mock_engine`
and `engine_from_config`.

This makes it possible to import `Engine` directly from `sqlmodel` and use it
for type hints when writing your own engine/session helpers, mirroring how
SQLAlchemy exposes it:

```python
from sqlmodel import Engine, create_engine, Session

def make_engine(url: str) -> Engine:
    return create_engine(url)

def get_session(engine: Engine) -> Session:
    return Session(engine)

```

The export is added next to the other sqlalchemy.engine imports in
sqlmodel/__init__.py, following the existing import X as X re-export
convention used throughout the file (so it is picked up as public API by type
checkers and linters).

## Checklist

- [ ] This PR is an obvious typo fix, or it links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [ ] Coverage stays at 100%.
- [ ] The documentation explains the change if needed.