### PR TITLE
chore: improve sqlmodel maintenance path

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ def cov_tmp_path(tmp_path: Path) -> Generator[Path, None, None]:
         shutil.copy(coverage_path, coverage_destiny_path)
 
 
-def coverage_run(*, module: str, cwd: str | Path) -> subprocess.CompletedProcess:
+def coverage_run(*, module: str, cwd: str | Path) -> subprocess.CompletedProcess[str]:
     result = subprocess.run(
         [
             "coverage",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Annotated
 
 import pytest
@@ -216,3 +217,11 @@ def test_foreign_key_ondelete_with_annotated(clear_sqlmodel):
     assert len(foreign_keys) == 1
     assert foreign_keys[0].ondelete == "CASCADE"
     assert team_id_column.nullable is False
+
+
+def test_coverage_run_reports_failure_on_bad_module(cov_tmp_path: Path) -> None:
+    from tests.conftest import coverage_run
+    result = coverage_run(module="nonexistent_module_xyz", cwd=cov_tmp_path)
+    assert result.returncode != 0
+    assert isinstance(result.stdout, str)
+    assert isinstance(result.stderr, str)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -221,6 +221,7 @@ def test_foreign_key_ondelete_with_annotated(clear_sqlmodel):
 
 def test_coverage_run_reports_failure_on_bad_module(cov_tmp_path: Path) -> None:
     from tests.conftest import coverage_run
+
     result = coverage_run(module="nonexistent_module_xyz", cwd=cov_tmp_path)
     assert result.returncode != 0
     assert isinstance(result.stdout, str)


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in tests/conftest.py, tests/test_main.py related to Python typing, tests, CLI ergonomics, observability; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.