### PR TITLE
fix: support StringConstraints metadata in SQLAlchemy type generation

### DIFF
--- a/sqlmodel/_compat.py
+++ b/sqlmodel/_compat.py
@@ -20,6 +20,7 @@ from annotated_types import MaxLen
 from pydantic import VERSION as P_VERSION
 from pydantic import BaseModel
 from pydantic import ConfigDict as ConfigDict
+from pydantic import StringConstraints as StringConstraints
 from pydantic._internal._fields import PydanticMetadata
 from pydantic._internal._model_construction import ModelMetaclass as ModelMetaclass
 from pydantic._internal._repr import Representation as Representation
@@ -200,7 +201,7 @@ def get_sa_type_from_field(field: Any) -> Any:
 
 def get_field_metadata(field: Any) -> Any:
     for meta in field.metadata:
-        if isinstance(meta, (PydanticMetadata, MaxLen)):
+        if isinstance(meta, (PydanticMetadata, MaxLen, StringConstraints)):
             return meta
     return FakeMetadata()
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -216,3 +216,14 @@ def test_foreign_key_ondelete_with_annotated(clear_sqlmodel):
     assert len(foreign_keys) == 1
     assert foreign_keys[0].ondelete == "CASCADE"
     assert team_id_column.nullable is False
+
+
+def test_string_constraints_max_length(clear_sqlmodel):
+    from typing import Annotated
+    from pydantic import StringConstraints
+
+    class Item(SQLModel, table=True):
+        id: int | None = Field(default=None, primary_key=True)
+        name: Annotated[str, StringConstraints(max_length=50)]
+
+    assert Item.__table__.c.name.type.length == 50

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -220,6 +220,7 @@ def test_foreign_key_ondelete_with_annotated(clear_sqlmodel):
 
 def test_string_constraints_max_length(clear_sqlmodel):
     from typing import Annotated
+
     from pydantic import StringConstraints
 
     class Item(SQLModel, table=True):


### PR DESCRIPTION
## Summary

When using Pydantic v2's `StringConstraints` inside `Annotated`, SQLModel correctly applies validation constraints but does not propagate `max_length` to the generated SQLAlchemy column type.

For example:

```python
from typing import Annotated
from pydantic import StringConstraints

class Item(SQLModel, table=True):
    id: int | None = Field(default=None, primary_key=True)
    name: Annotated[str, StringConstraints(max_length=50)]
```

currently generates a column with no length constraint, even though `max_length=50` is declared.

## Root Cause

`get_field_metadata()` recognizes `PydanticMetadata` and `MaxLen` metadata objects, but does not recognize `StringConstraints`, causing the metadata extractor to return `FakeMetadata()` instead of the constraint object.

As a result, `get_sqlalchemy_type()` cannot read `max_length` and falls back to an unconstrained string type.

## Changes

* Add support for `StringConstraints` in `get_field_metadata()`.
* Add a regression test verifying that `Annotated[str, StringConstraints(max_length=50)]` produces a SQLAlchemy column with `length == 50`.

## Testing

Added a regression test that fails on the current implementation and passes with this change.
