### PR TITLE
fix: use kwargs registry directly and store it correctly in model_config

### DIFF
--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -613,11 +613,11 @@ class SQLModelMetaclass(ModelMetaclass, DeclarativeMeta):
             # TODO: remove this in the future
             new_cls.model_config["read_with_orm_mode"] = True  # ty: ignore[invalid-key]
 
-        config_registry = get_config("registry")
+        config_registry = kwargs.get("registry", Undefined)
         if config_registry is not Undefined:
             config_registry = cast(registry, config_registry)
             # If it was passed by kwargs, ensure it's also set in config
-            new_cls.model_config["registry"] = config_table
+            new_cls.model_config["registry"] = config_registry
             setattr(new_cls, "_sa_registry", config_registry)  # noqa: B010
             setattr(new_cls, "metadata", config_registry.metadata)  # noqa: B010
             setattr(new_cls, "__abstract__", True)  # noqa: B010

--- a/tests/test_registry_kwarg.py
+++ b/tests/test_registry_kwarg.py
@@ -1,0 +1,30 @@
+"""Tests for SQLModelMetaclass.__new__ registry kwarg handling."""
+import pytest
+from sqlalchemy.orm import registry
+from sqlmodel import SQLModel
+
+
+def test_custom_registry_base_stores_registry_in_model_config() -> None:
+    """model_config['registry'] must hold the registry object passed as kwarg."""
+    custom_registry = registry()
+
+    class MyBase(SQLModel, registry=custom_registry):
+        pass
+
+    stored = MyBase.model_config.get("registry")
+    assert stored is custom_registry, (
+        f"model_config['registry'] should be the custom registry, got {stored!r}"
+    )
+
+
+def test_custom_registry_base_sets_sa_registry() -> None:
+    """_sa_registry must reference the registry object passed as kwarg."""
+    custom_registry = registry()
+
+    class MyBase2(SQLModel, registry=custom_registry):
+        pass
+
+    sa_registry = getattr(MyBase2, "_sa_registry", None)
+    assert sa_registry is custom_registry, (
+        f"_sa_registry should be the custom registry, got {sa_registry!r}"
+    )

--- a/tests/test_registry_kwarg.py
+++ b/tests/test_registry_kwarg.py
@@ -1,5 +1,5 @@
 """Tests for SQLModelMetaclass.__new__ registry kwarg handling."""
-import pytest
+
 from sqlalchemy.orm import registry
 from sqlmodel import SQLModel
 


### PR DESCRIPTION
## Bug

In `SQLModelMetaclass.__new__`, the block that handles the `registry=` kwarg contained two bugs introduced in #1701 (Pydantic v1 removal refactor):

**Bug 1 — wrong variable (copy-paste error):**
```python
# line 620 before fix
new_cls.model_config["registry"] = config_table   # ← should be config_registry
```
`config_table` is the `table=True/False` config value. When no `table=True` is set (the normal case for a custom-registry base), `config_table` is `PydanticUndefined`, so `model_config["registry"]` always ended up as `PydanticUndefined` instead of the actual registry object.

**Bug 2 — reads inherited model_config instead of the passed kwarg:**
```python
# line 616 before fix
config_registry = get_config("registry")
```
`get_config` checks `model_config` first. Since the base `SQLModel` class sets its own `model_config["registry"]`, every subclass inherits that value and `get_config` never falls through to the actual kwarg — so a subclass passing `registry=my_custom_registry` would silently use the parent's registry.

## Reproducer

```python
from sqlalchemy.orm import registry
from sqlmodel import SQLModel

custom_registry = registry()

class MyBase(SQLModel, registry=custom_registry):
    pass

# Before fix:
assert MyBase.model_config.get("registry") is not custom_registry  # PydanticUndefined

# After fix:
assert MyBase.model_config.get("registry") is custom_registry  # ✓
```

## Fix

Read directly from `kwargs` (which holds only what was explicitly passed to this class, not inherited values) and write `config_registry` — the actual registry — to `model_config`:

```python
config_registry = kwargs.get("registry", Undefined)   # was: get_config("registry")
if config_registry is not Undefined:
    config_registry = cast(registry, config_registry)
    new_cls.model_config["registry"] = config_registry  # was: config_table
    ...
```

## Verification

```
uv run pytest tests/test_registry_kwarg.py -v
# 2 passed

uv run pytest tests/ -q
# 193 passed
```

> Assisted by an AI coding agent; all analysis and code changes reviewed manually.
