### PR TITLE
👷 Add GH workflow to bump pre-commit hook versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,20 +31,3 @@ updates:
         dependency-type: "development"
         patterns:
           - "*"
-  # pre-commit
-  - package-ecosystem: "pre-commit"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    cooldown:
-      default-days: 7
-    commit-message:
-      prefix: ⬆
-    labels:
-      - "internal"
-      - "dependencies"
-      - "pre-commit"
-    groups:
-      pre-commit:
-        patterns:
-          - "*"

--- a/.github/workflows/bump-pre-commit-hooks.yml
+++ b/.github/workflows/bump-pre-commit-hooks.yml
@@ -1,0 +1,67 @@
+name: Bump pre-commit hooks
+
+on:
+  schedule:
+    - cron: "0 12 1 * *"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  bump-pre-commit-hooks:
+    if: github.repository_owner == 'fastapi'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          token: ${{ secrets.SQLMODEL_LATEST_CHANGES }}
+          persist-credentials: true
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version-file: ".python-version"
+      - name: Setup uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          # Before upgrading uv version, make sure astral-sh/setup-uv knows its checksum.
+          # See: https://github.com/astral-sh/setup-uv/issues/851#issuecomment-4282017837
+          version: "0.11.18"
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+      - name: Bump pre-commit hooks
+        run: uv run prek auto-update --freeze --cooldown-days 7
+      - name: Create pull request
+        env:
+          GH_TOKEN: ${{ secrets.SQLMODEL_LATEST_CHANGES }}
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet; then
+            echo "No pre-commit hook updates available"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          branch="bump-pre-commit-hooks"
+          git switch -C "$branch"
+          git add .pre-commit-config.yaml
+          git commit -m "⬆ Bump pre-commit hooks"
+          git push --force origin "$branch"
+          if [ -z "$(gh pr list --head "$branch" --state open --json number --jq '.[].number')" ]; then
+            gh pr create \
+              --base "$BASE_BRANCH" \
+              --head "$branch" \
+              --title "⬆ Bump pre-commit hooks" \
+              --body "Bump pre-commit hook versions via \`prek auto-update --freeze --cooldown-days 7\`." \
+              --label internal \
+              --label dependencies \
+              --label pre-commit
+          else
+            echo "PR for \"$branch\" already open; branch updated in place."
+          fi


### PR DESCRIPTION
Dependabot doesn't work well with "pre-commit" package ecosystem..

This PR disables Dependabot "pre-commit" package ecosystem and adds a GH workflow to bump pre-commit hooks using `prek auto-update --freeze --cooldown-days 7` command instead.

**Note:** this workflow re-uses existing `SQLMODEL_LATEST_CHANGES` token as it's done in `prepare-release.yml`

---

Same as https://github.com/fastapi/fastapi/pull/15873 (except token name `FASTAPI_PR_TOKEN` -> `SQLMODEL_LATEST_CHANGES`)