### PR TITLE
Add SET DEFAULT and NO ACTION to OnDeleteType

### DIFF
--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -87,7 +87,7 @@ IncEx: TypeAlias = (
     | Mapping[int, Union["IncEx", bool]]
     | Mapping[str, Union["IncEx", bool]]
 )
-OnDeleteType = Literal["CASCADE", "SET NULL", "RESTRICT"]
+OnDeleteType = Literal["CASCADE", "SET NULL", "SET DEFAULT", "RESTRICT", "NO ACTION"]
 
 
 def __dataclass_transform__(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,6 +3,7 @@ from typing import Annotated
 import pytest
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import RelationshipProperty
+from sqlalchemy.schema import CreateTable
 from sqlmodel import Field, Relationship, Session, SQLModel, create_engine, select
 
 
@@ -216,3 +217,26 @@ def test_foreign_key_ondelete_with_annotated(clear_sqlmodel):
     assert len(foreign_keys) == 1
     assert foreign_keys[0].ondelete == "CASCADE"
     assert team_id_column.nullable is False
+
+
+@pytest.mark.parametrize("ondelete", ["SET DEFAULT", "NO ACTION"])
+def test_foreign_key_ondelete_referential_actions(clear_sqlmodel, ondelete):
+    class Team(SQLModel, table=True):
+        id: int | None = Field(default=None, primary_key=True)
+
+    class Hero(SQLModel, table=True):
+        id: int | None = Field(default=None, primary_key=True)
+        team_id: int | None = Field(
+            default=None, foreign_key="team.id", ondelete=ondelete
+        )
+
+    engine = create_engine("sqlite://")
+    SQLModel.metadata.create_all(engine)
+
+    hero_table = Hero.__table__  # type: ignore[attr-defined]
+    foreign_keys = list(hero_table.c.team_id.foreign_keys)
+    assert len(foreign_keys) == 1
+    assert foreign_keys[0].ondelete == ondelete
+
+    ddl = str(CreateTable(hero_table).compile(engine))
+    assert f"ON DELETE {ondelete}" in ddl


### PR DESCRIPTION

`OnDeleteType`, the `Literal` that types the public `Field(ondelete=...)`
parameter, only listed three of the five standard SQL referential actions:
`CASCADE`, `SET NULL` and `RESTRICT`. The remaining two, `SET DEFAULT` and
`NO ACTION`, are valid everywhere else in the stack: `ondelete` is passed
straight through to SQLAlchemy's `ForeignKey(ondelete=...)`, which emits
`ON DELETE <value>` for any of them, and SQL defines exactly these five actions.

Because the literal omitted them, a type checker (mypy/pyright/ty) rejected a
perfectly valid schema, for example:

```python
class Hero(SQLModel, table=True):
    id: int | None = Field(default=None, primary_key=True)
    team_id: int | None = Field(
        default=None, foreign_key="team.id", ondelete="NO ACTION"
    )
```

The only workarounds were casting to `Any` or dropping down to `sa_column`.
`NO ACTION` is the default referential action in PostgreSQL and most databases,
and `SET DEFAULT` pairs naturally with a column `server_default`, so both are
things people legitimately want to spell out.

This adds the two missing actions to `OnDeleteType`. There is no runtime change
(the value was always passed through unchanged); this only corrects the static
type. Reported in #1839.

## Tests

Added a parametrized regression test over the two newly typed actions that
asserts both the resulting foreign key's `ondelete` and the generated
`ON DELETE <action>` DDL, mirroring the existing
`test_foreign_key_ondelete_with_annotated`.