### PR TITLE
fix: merge field constraints across all metadata items

### DIFF
--- a/sqlmodel/_compat.py
+++ b/sqlmodel/_compat.py
@@ -199,10 +199,15 @@ def get_sa_type_from_field(field: Any) -> Any:
 
 
 def get_field_metadata(field: Any) -> Any:
+    result = FakeMetadata()
     for meta in field.metadata:
         if isinstance(meta, (PydanticMetadata, MaxLen)):
-            return meta
-    return FakeMetadata()
+            for attr in ("max_length", "max_digits", "decimal_places"):
+                if getattr(result, attr, None) is None:
+                    value = getattr(meta, attr, None)
+                    if value is not None:
+                        setattr(result, attr, value)
+    return result
 
 
 def sqlmodel_table_construct(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -216,3 +216,26 @@ def test_foreign_key_ondelete_with_annotated(clear_sqlmodel):
     assert len(foreign_keys) == 1
     assert foreign_keys[0].ondelete == "CASCADE"
     assert team_id_column.nullable is False
+
+
+def test_metadata_constraints_not_shadowed_by_earlier_metadata(clear_sqlmodel):
+    from decimal import Decimal
+
+    from pydantic import Field as PydanticField
+
+    class Item(SQLModel, table=True):
+        id: int | None = Field(default=None, primary_key=True)
+        code: Annotated[
+            str, PydanticField(pattern=r"^[a-z]+$"), PydanticField(max_length=10)
+        ]
+        price: Annotated[
+            Decimal,
+            PydanticField(allow_inf_nan=False),
+            PydanticField(max_digits=8, decimal_places=2),
+        ]
+
+    code_column = Item.__table__.c.code  # type: ignore[attr-defined]
+    price_column = Item.__table__.c.price  # type: ignore[attr-defined]
+    assert code_column.type.length == 10
+    assert price_column.type.precision == 8
+    assert price_column.type.scale == 2


### PR DESCRIPTION

`get_field_metadata` returns the first `field.metadata` item that is a
`PydanticMetadata` or `MaxLen` and stops there. Pydantic v2 spreads a field's
constraints across several separate metadata items, so when a matching item that
does not carry the length or precision precedes the one that does, `max_length`,
`max_digits`, and `decimal_places` are silently dropped. The generated SQLAlchemy
column then comes out unbounded (`VARCHAR` / `NUMERIC` with no length or
precision) even though the field declared a limit.

This is order dependent: putting the size constraint first happens to work, and
reordering the annotation makes the same field lose its constraint, which is
surprising.

## Reproduction

On `main`:

```python
from decimal import Decimal
from typing import Annotated

from pydantic import Field as PydanticField
from sqlmodel import Field, SQLModel


class Item(SQLModel, table=True):
    id: int | None = Field(default=None, primary_key=True)
    # size constraint comes AFTER a non-size constraint
    code: Annotated[str, PydanticField(pattern=r"^[a-z]+$"), PydanticField(max_length=10)]
    price: Annotated[
        Decimal,
        PydanticField(allow_inf_nan=False),
        PydanticField(max_digits=8, decimal_places=2),
    ]


print(Item.__table__.c.code.type.length)      # None  (expected 10)
print(Item.__table__.c.price.type.precision)  # None  (expected 8)
print(Item.__table__.c.price.type.scale)      # None  (expected 2)
```

Swapping the annotation order so the size constraint comes first yields the
correct `10` / `8` / `2`, which confirms the loss is purely order dependent.

The `Decimal` case is worse than it first looks: Pydantic stores `max_digits`
and `decimal_places` in two separate metadata items, so before this change the
first-match `return` could keep the precision but drop the scale (or vice versa)
regardless of annotation order.

## Fix

Instead of returning the first matching metadata item, scan all matching items
and merge `max_length`, `max_digits`, and `decimal_places` into a single result,
keeping the first non-None value found for each attribute. `FakeMetadata`
(already the empty fallback here, and declaring exactly those three attributes)
is reused as the aggregator, so the change stays small.

The only consumer, `get_sqlalchemy_type`, reads just those three attributes via
`getattr(..., None)`, so fields that carry all their constraints on a single
metadata item behave exactly as before. Only fields whose constraints were split
across items (and were therefore already broken) change behavior.

## Tests

Adds `test_metadata_constraints_not_shadowed_by_earlier_metadata`, covering both
the `str` (`max_length` after `pattern`) and `Decimal` (`max_digits` /
`decimal_places` after `allow_inf_nan`) cases. It fails on `main`
(`assert None == 10`) and passes with this change. The full suite (`pytest
tests`) and the linters (`ty`, `ruff check`, `ruff format --check`) pass locally.
