### PR TITLE
Correct create_engine description in create-db-and-table tutorial

### DIFF
--- a/docs/tutorial/create-db-and-table.md
+++ b/docs/tutorial/create-db-and-table.md
@@ -204,9 +204,9 @@ If you didn't know about SQLAlchemy before and are just learning **SQLModel**, y
 
 You can read a lot more about the engine in the [SQLAlchemy documentation](https://docs.sqlalchemy.org/en/14/tutorial/engine.html).
 
-**SQLModel** defines its own `create_engine()` function. It is the same as SQLAlchemy's `create_engine()`, but with the difference that it defaults to use `future=True` (which means that it uses the style of the latest SQLAlchemy, 1.4, and the future 2.0).
+**SQLModel** re-exports SQLAlchemy's `create_engine()` directly, so `sqlmodel.create_engine` is the same function as `sqlalchemy.create_engine`. SQLModel requires SQLAlchemy 2.0 or above, which uses the modern 2.0 style by default.
 
-And SQLModel's version of `create_engine()` is type annotated internally, so your editor will be able to help you with autocompletion and inline errors.
+SQLAlchemy's `create_engine()` is type annotated, so your editor will be able to help you with autocompletion and inline errors.
 
 ## Create the Database and Table
 


### PR DESCRIPTION

The "Engine Technical Details" tip in the create-db-and-table tutorial describes
`create_engine()` in a way that no longer matches SQLModel:

> **SQLModel** defines its own `create_engine()` function. It is the same as
> SQLAlchemy's `create_engine()`, but with the difference that it defaults to use
> `future=True` (which means that it uses the style of the latest SQLAlchemy, 1.4,
> and the future 2.0).
>
> And SQLModel's version of `create_engine()` is type annotated internally, ...

SQLModel no longer defines its own `create_engine()`. Since the SQLAlchemy 2.0
upgrade it is a direct re-export:

```python
# sqlmodel/__init__.py
from sqlalchemy.engine import create_engine as create_engine
```

so `sqlmodel.create_engine is sqlalchemy.create_engine` is `True`. There is no
wrapper anymore, and the `future=True` / "latest SQLAlchemy, 1.4, and the future
2.0" framing is obsolete: `pyproject.toml` requires `SQLAlchemy >=2.0.14,<2.1.0`,
where the 2.0 style is the only mode and `future` is no longer a meaningful toggle
(SQLAlchemy 2.0 rejects `future=False`). The type annotations now come from
SQLAlchemy itself (`create_engine` returns an annotated `Engine`).

This updates the two sentences to say that SQLModel re-exports SQLAlchemy's
`create_engine()` directly, requires SQLAlchemy 2.0+, and that SQLAlchemy's
`create_engine()` is type annotated. Docs-only, no code change.
