### PR TITLE
fix(sql): accept QueryableAttribute and ColumnElement in col() helper

### DIFF
--- a/sqlmodel/sql/expression.py
+++ b/sqlmodel/sql/expression.py
@@ -199,7 +199,13 @@ def within_group(
 def col(column_expression: _T) -> Mapped[_T]:
     if not isinstance(
         column_expression,
-        (ColumnClause, Column, InstrumentedAttribute, QueryableAttribute, ColumnElement),
+        (
+            ColumnClause,
+            Column,
+            InstrumentedAttribute,
+            QueryableAttribute,
+            ColumnElement,
+        ),
     ):
         raise RuntimeError(f"Not a SQLAlchemy column: {column_expression}")
     return column_expression  # type: ignore

--- a/sqlmodel/sql/expression.py
+++ b/sqlmodel/sql/expression.py
@@ -18,7 +18,7 @@ from sqlalchemy import (
     TypeCoerce,
     WithinGroup,
 )
-from sqlalchemy.orm import InstrumentedAttribute, Mapped
+from sqlalchemy.orm import InstrumentedAttribute, Mapped, QueryableAttribute
 from sqlalchemy.sql._typing import (
     _ColumnExpressionArgument,
     _ColumnExpressionOrLiteralArgument,
@@ -197,6 +197,9 @@ def within_group(
 
 
 def col(column_expression: _T) -> Mapped[_T]:
-    if not isinstance(column_expression, (ColumnClause, Column, InstrumentedAttribute)):
+    if not isinstance(
+        column_expression,
+        (ColumnClause, Column, InstrumentedAttribute, QueryableAttribute, ColumnElement),
+    ):
         raise RuntimeError(f"Not a SQLAlchemy column: {column_expression}")
     return column_expression  # type: ignore


### PR DESCRIPTION
## Description
This PR updates the col helper in sqlmodel/sql/expression.py to accept QueryableAttribute and ColumnElement instances.

## Details
- Prevents RuntimeError when passing hybrid properties, descriptors, or column elements to col().