### PR TITLE
fix(compat): forward by_alias and by_name parameters in model_validate and sqlmodel_validate

### DIFF
--- a/sqlmodel/_compat.py
+++ b/sqlmodel/_compat.py
@@ -281,6 +281,8 @@ def sqlmodel_validate(
     from_attributes: bool | None = None,
     context: dict[str, Any] | None = None,
     update: dict[str, Any] | None = None,
+    by_alias: bool | None = None,
+    by_name: bool | None = None,
 ) -> _TSQLModel:
     if not is_table_model_class(cls):
         new_obj: _TSQLModel = cls.__new__(cls)
@@ -303,6 +305,8 @@ def sqlmodel_validate(
         strict=strict,
         from_attributes=from_attributes,
         context=context,
+        by_alias=by_alias,
+        by_name=by_name,
         self_instance=new_obj,
     )
     # Capture fields set to restore it later

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -877,6 +877,8 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
         from_attributes: bool | None = None,
         context: builtins.dict[str, Any] | None = None,
         update: builtins.dict[str, Any] | None = None,
+        by_alias: bool | None = None,
+        by_name: bool | None = None,
     ) -> _TSQLModel:
         return sqlmodel_validate(
             cls=cls,
@@ -885,6 +887,8 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
             from_attributes=from_attributes,
             context=context,
             update=update,
+            by_alias=by_alias,
+            by_name=by_name,
         )
 
     def model_dump(


### PR DESCRIPTION
## Description
This PR forwards `by_alias` and `by_name` parameters in `SQLModel.model_validate()` and `sqlmodel_validate()` in `sqlmodel/_compat.py` and `sqlmodel/main.py`.

## Details
- Fixes compatibility with Pydantic v2 `validate_python` when validating models with alias settings.