### PR TITLE
🔐 Use PR Submit for pull requests

### DIFF
--- a/.github/pr-submit.yml
+++ b/.github/pr-submit.yml
@@ -1,0 +1,3 @@
+workflows:
+  - .github/workflows/bump-pre-commit-hooks.yml
+  - .github/workflows/prepare-release.yml

--- a/.github/workflows/bump-pre-commit-hooks.yml
+++ b/.github/workflows/bump-pre-commit-hooks.yml
@@ -12,6 +12,9 @@ jobs:
     if: github.repository_owner == 'fastapi'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Dump GitHub context
         env:
@@ -19,8 +22,7 @@ jobs:
         run: echo "$GITHUB_CONTEXT"
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          token: ${{ secrets.SQLMODEL_LATEST_CHANGES }}
-          persist-credentials: true
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -36,9 +38,12 @@ jobs:
             uv.lock
       - name: Bump pre-commit hooks
         run: uv run prek auto-update --freeze --cooldown-days 7
+      - name: Get PR Submit token
+        id: pr-submit
+        uses: tiangolo/pr-submit@d802fdf59bde80bc3eb8bd3259f4cbeec63de4aa # 0.0.1
       - name: Create pull request
         env:
-          GH_TOKEN: ${{ secrets.SQLMODEL_LATEST_CHANGES }}
+          GH_TOKEN: ${{ steps.pr-submit.outputs.token }}
           BASE_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
@@ -46,12 +51,13 @@ jobs:
             echo "No pre-commit hook updates available"
             exit 0
           fi
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "pr-submit[bot]"
+          git config user.email "pr-submit[bot]@users.noreply.github.com"
           branch="bump-pre-commit-hooks"
           git switch -C "$branch"
           git add .pre-commit-config.yaml
           git commit -m "⬆ Bump pre-commit hooks"
+          gh auth setup-git
           git push --force origin "$branch"
           if [ -z "$(gh pr list --head "$branch" --state open --json number --jq '.[].number')" ]; then
             gh pr create \

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -23,9 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      contents: write
-      issues: write
-      pull-requests: write
+      contents: read
+      id-token: write
     env:
       PREPARE_RELEASE_VERSION_FILE: sqlmodel/__init__.py
       PREPARE_RELEASE_RELEASE_NOTES_FILE: docs/release-notes.md
@@ -36,8 +35,7 @@ jobs:
         run: echo "$GITHUB_CONTEXT"
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          token: ${{ secrets.SQLMODEL_LATEST_CHANGES }} # zizmor: ignore[secrets-outside-env]
-          persist-credentials: true
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -59,18 +57,22 @@ jobs:
           version="$(uv run python scripts/prepare_release.py current-version)"
           echo "$version"
           echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Get PR Submit token
+        id: pr-submit
+        uses: tiangolo/pr-submit@d802fdf59bde80bc3eb8bd3259f4cbeec63de4aa # 0.0.1
       - name: Create release pull request
         env:
-          GH_TOKEN: ${{ secrets.SQLMODEL_LATEST_CHANGES }}
+          GH_TOKEN: ${{ steps.pr-submit.outputs.token }}
           VERSION: ${{ steps.release-version.outputs.version }}
         run: |
           set -euo pipefail
           branch="release-${VERSION}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "pr-submit[bot]"
+          git config user.email "pr-submit[bot]@users.noreply.github.com"
           git switch -c "$branch"
           git add "$PREPARE_RELEASE_VERSION_FILE" "$PREPARE_RELEASE_RELEASE_NOTES_FILE"
           git commit -m "Release version ${VERSION}"
+          gh auth setup-git
           git push --set-upstream origin "$branch"
           gh pr create \
             --base main \


### PR DESCRIPTION
Replace the long-lived personal access token used by workflows that create pull requests with a short-lived repository-scoped token from PR Submit.

The workflows now request the token through GitHub OIDC, check out without persisted credentials, authenticate Git with `gh auth setup-git`, and attribute commits to `pr-submit[bot]`. The repository allowlist includes only the migrated workflows.

Validated with YAML parsing, `git diff --check`, and an online zizmor audit.

## AI Disclaimer

Created with gpt-5.6-sol and reviewed by hand.
