### PR TITLE
fix: set relationships when model_validate receives a dict

### DIFF
--- a/sqlmodel/_compat.py
+++ b/sqlmodel/_compat.py
@@ -320,7 +320,13 @@ def sqlmodel_validate(
     # Get and set any relationship objects
     if is_table_model_class(cls):
         for key in new_obj.__sqlmodel_relationships__:
-            value = getattr(use_obj, key, Undefined)
+            # use_obj can be a dict (the input obj, or the merged obj when
+            # update is passed), so read relationships accordingly instead of
+            # assuming attribute access.
+            if isinstance(use_obj, dict):
+                value = use_obj.get(key, Undefined)
+            else:
+                value = getattr(use_obj, key, Undefined)
             if value is not Undefined:
                 setattr(new_obj, key, value)
     return new_obj

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -29,3 +29,29 @@ def test_validation_pydantic_v2(clear_sqlmodel):
 
     with pytest.raises(ValidationError):
         Hero.model_validate({"name": None, "age": 25})
+
+
+def test_validate_dict_sets_relationship(clear_sqlmodel):
+    """A relationship passed inside the dict given to model_validate must be
+    set, consistent with the constructor and with model_validate(object)."""
+    from typing import List, Optional
+
+    from sqlmodel import Field, Relationship
+
+    class Team(SQLModel, table=True):
+        id: Optional[int] = Field(default=None, primary_key=True)
+        name: str
+        heroes: List["Hero"] = Relationship(back_populates="team")
+
+    class Hero(SQLModel, table=True):
+        id: Optional[int] = Field(default=None, primary_key=True)
+        name: str
+        team_id: Optional[int] = Field(default=None, foreign_key="team.id")
+        team: Optional[Team] = Relationship(back_populates="heroes")
+
+    team = Team(name="Avengers")
+
+    # constructor already works; model_validate must match it
+    assert Hero(name="IronMan", team=team).team is team
+    assert Hero.model_validate({"name": "Thor", "team": team}).team is team
+    assert Hero.model_validate({"name": "Hulk"}, update={"team": team}).team is team

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -34,20 +34,19 @@ def test_validation_pydantic_v2(clear_sqlmodel):
 def test_validate_dict_sets_relationship(clear_sqlmodel):
     """A relationship passed inside the dict given to model_validate must be
     set, consistent with the constructor and with model_validate(object)."""
-    from typing import List, Optional
 
     from sqlmodel import Field, Relationship
 
     class Team(SQLModel, table=True):
-        id: Optional[int] = Field(default=None, primary_key=True)
+        id: int | None = Field(default=None, primary_key=True)
         name: str
-        heroes: List["Hero"] = Relationship(back_populates="team")
+        heroes: list["Hero"] = Relationship(back_populates="team")
 
     class Hero(SQLModel, table=True):
-        id: Optional[int] = Field(default=None, primary_key=True)
+        id: int | None = Field(default=None, primary_key=True)
         name: str
-        team_id: Optional[int] = Field(default=None, foreign_key="team.id")
-        team: Optional[Team] = Relationship(back_populates="heroes")
+        team_id: int | None = Field(default=None, foreign_key="team.id")
+        team: Team | None = Relationship(back_populates="heroes")
 
     team = Team(name="Avengers")
 


### PR DESCRIPTION
## Summary

`sqlmodel_validate` (which backs `SQLModel.model_validate` and the deprecated `from_orm`/`parse_obj`) sets relationships with attribute access:

```python
for key in new_obj.__sqlmodel_relationships__:
    value = getattr(use_obj, key, Undefined)
    if value is not Undefined:
        setattr(new_obj, key, value)
```

But `use_obj` is a plain `dict` in the common case: it is the input `obj` when a dict is passed, or `{**obj, **update}` when `update=` is given. `getattr(some_dict, "team", Undefined)` never reads dict keys, so it always returns `Undefined` and the relationship is silently dropped, no error.

This makes `model_validate` inconsistent with both the constructor and `model_validate(object)`:

```python
team = Team(name="Avengers")
Hero(name="IronMan", team=team).team is team                         # True
Hero.model_validate({"name": "Thor", "team": team}).team is team     # False (dropped)
Hero.model_validate(SimpleNamespace(name="Loki", team=team)).team    # works (object -> getattr)
Hero.model_validate({"name": "Hulk"}, update={"team": team}).team    # False (merged dict, dropped)
```

The sibling `sqlmodel_table_construct` already handles this correctly with `values.get(key, Undefined)`.

## Fix

Read the relationship via `dict.get` when `use_obj` is a dict, falling back to `getattr` otherwise (mirroring `sqlmodel_table_construct`). This also fixes the `update=` path.

## Test

Added `test_validate_dict_sets_relationship`: a relationship passed in the dict to `model_validate` (and via `update=`) must be set, matching the constructor. It fails before the change and passes after. The existing validation tests only pass scalar fields, so this path was uncovered.
