### PR TITLE
tests: import ValidationError directly from pydantic to avoid deprecation warning

### DIFF
--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,5 +1,5 @@
 import pytest
-from pydantic.error_wrappers import ValidationError
+from pydantic import ValidationError
 from sqlmodel import SQLModel
 
 


### PR DESCRIPTION
### Summary
- In `tests/test_validation.py`, import `ValidationError` directly from `pydantic` instead of deprecated `pydantic.error_wrappers`, resolving `PydanticDeprecatedSince20` warning.