### PR TITLE
docs: capitalize Instead in session.execute docstrings

### DIFF
--- a/sqlmodel/orm/session.py
+++ b/sqlmodel/orm/session.py
@@ -97,7 +97,7 @@ class Session(_Session):
         heroes = session.execute(select(Hero)).scalars().all()
         ```
 
-        instead you could use `exec()`:
+        Instead you could use `exec()`:
 
         ```Python
         heroes = session.exec(select(Hero)).all()
@@ -127,7 +127,7 @@ class Session(_Session):
         heroes = session.execute(select(Hero)).scalars().all()
         ```
 
-        instead you could use `exec()`:
+        Instead you could use `exec()`:
 
         ```Python
         heroes = session.exec(select(Hero)).all()


### PR DESCRIPTION
### Summary
- Capitalize `Instead` at the start of the sentence in `Session.execute` docstrings.