### PR TITLE
⬆️ Bump Typer min version to `0.26.1`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ docs = [
     "mkdocstrings[python] >=1.0.3",
     "pillow >=12.1.1",
     "pyyaml >=5.3.1",
-    "typer >=0.24.1",
+    "typer >=0.26.1",
     "zensical>=0.0.42",
 ]
 github-actions = [
@@ -84,7 +84,7 @@ tests = [
     "pytest >=7.0.1",
     "ruff >=0.15.6",
     "ty>=0.0.25",
-    "typer >=0.24.1",
+    "typer >=0.26.1",
     "typing-extensions >=4.15.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1757,7 +1757,7 @@ dev = [
     { name = "pyyaml", specifier = ">=5.3.1" },
     { name = "ruff", specifier = ">=0.15.6" },
     { name = "ty", specifier = ">=0.0.25" },
-    { name = "typer", specifier = ">=0.24.1" },
+    { name = "typer", specifier = ">=0.26.1" },
     { name = "typing-extensions", specifier = ">=4.15.0" },
     { name = "zensical", specifier = ">=0.0.42" },
     { name = "zizmor", specifier = ">=1.23.1" },
@@ -1772,7 +1772,7 @@ docs = [
     { name = "mkdocstrings", extras = ["python"], specifier = ">=1.0.3" },
     { name = "pillow", specifier = ">=12.1.1" },
     { name = "pyyaml", specifier = ">=5.3.1" },
-    { name = "typer", specifier = ">=0.24.1" },
+    { name = "typer", specifier = ">=0.26.1" },
     { name = "zensical", specifier = ">=0.0.42" },
 ]
 github-actions = [
@@ -1792,7 +1792,7 @@ tests = [
     { name = "pytest", specifier = ">=7.0.1" },
     { name = "ruff", specifier = ">=0.15.6" },
     { name = "ty", specifier = ">=0.0.25" },
-    { name = "typer", specifier = ">=0.24.1" },
+    { name = "typer", specifier = ">=0.26.1" },
     { name = "typing-extensions", specifier = ">=4.15.0" },
 ]
 


### PR DESCRIPTION
Typer version less than 0.26.0 has deprecation warnings with latest version of Click. It doesn't break anything now, but will stop working after Click 9.0 release.

🤖 This pull request was created with the help of AI (Codex).

Checked manually